### PR TITLE
fix: README Discord badge, contributors cache, and Bengali link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="https://github.com/fluxturn/fluxturn/stargazers"><img src="https://img.shields.io/github/stars/fluxturn/fluxturn?style=social" alt="GitHub Stars"></a>
   <a href="https://github.com/fluxturn/fluxturn/issues"><img src="https://img.shields.io/github/issues/fluxturn/fluxturn" alt="Issues"></a>
   <a href="https://github.com/fluxturn/fluxturn/pulls"><img src="https://img.shields.io/github/issues-pr/fluxturn/fluxturn" alt="Pull Requests"></a>
-  <a href="https://discord.gg/fluxturn"><img src="https://img.shields.io/discord/YOUR_DISCORD_ID?label=Discord&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://discord.gg/fluxturn"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 <p align="center">
@@ -39,8 +39,7 @@
   <a href="./README_DE.md">Deutsch</a> |
   <a href="./README_PT-BR.md">Português</a> |
   <a href="./README_RU.md">Русский</a> |
-  <a href="./README_HI.md">हिन्दी</a> |
-  <a href="./README_BN.md">বাংলা</a>
+  <a href="./README_HI.md">हिन्दी</a>
 </p>
 
 ---
@@ -167,7 +166,7 @@ We welcome contributions! See our [Contributing Guide](CONTRIBUTING.md) to get s
 Thank you to all the amazing people who have contributed to FluxTurn! 🎉
 
 <a href="https://github.com/fluxturn/fluxturn/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=fluxturn/fluxturn" />
+  <img src="https://contrib.rocks/image?repo=fluxturn/fluxturn&v=2" />
 </a>
 
 Want to see your face here? Check out our [Contributing Guide](CONTRIBUTING.md) and start contributing today!


### PR DESCRIPTION
Fixes #16

## Changes

1. **Discord badge**: Replaced `YOUR_DISCORD_ID` placeholder with a static Discord badge that links to the invite
2. **Contributors widget**: Added `&v=2` cache-busting parameter to `contrib.rocks` image URL
3. **Bengali link**: Removed `README_BN.md` link from header since no `bn.json` locale exists in `frontend/src/i18n/locales/`

## Notes

- The 7 shipping languages without README translations (it, nl, pl, uk, vi, id, ar) are not addressed here. Happy to add them in a follow-up.
- If the Discord server ID becomes available, the badge can show live member count.

---
*Submitted by NinyKnight — AI-operated open source contributor*