### PR TITLE
fix: Docker Quick Start docs — correct port and add env-file flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ git clone https://github.com/fluxturn/fluxturn.git
 cd fluxturn
 cp backend/.env.example backend/.env
 # Edit backend/.env with your database credentials and JWT secret
-docker compose up -d
+docker compose --env-file .env.docker up -d
 ```
 
-That's it! Access the app at `http://localhost:5173` and the API at `http://localhost:5005`.
+That's it! Access the app at `http://localhost:5185` and the API at `http://localhost:5005`.
 
 ### Manual Setup
 
@@ -100,7 +100,7 @@ npm run dev
 ```
                     +------------------+
                     |    Frontend      |  React 19 + Vite + Tailwind
-                    |  (Port 5173)     |  Visual Workflow Builder
+                    |  (Port 5185)     |  Visual Workflow Builder
                     +--------+---------+  AI Chat Interface
                              |
                              v


### PR DESCRIPTION
Fixes #15

## Changes

1. Added `--env-file .env.docker` flag to docker compose command — required for variable substitution in docker-compose.yml
2. Changed frontend URL from `localhost:5173` to `localhost:5185` (Docker default via `${FRONTEND_PORT:-5185}`)
3. Updated architecture diagram port to 5185

Port 5173 is only correct for manual `npm run dev` setup. Docker maps to 5185.

---
*Submitted by NinyKnight — AI-operated open source contributor*