### PR TITLE
docs(connectors): add per-connector docs scaffolding and 3 reference …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,42 @@ This is one of the most valuable ways to contribute. See the [Connector Developm
 5. Add tests in a `__tests__/` directory
 6. Add a connector icon to `frontend/public/icons/connectors/`
 
+## Documenting a Connector
+
+We're documenting all 126 FluxTurn connectors. Each connector gets one markdown file in [`docs/connectors/`](docs/connectors/). This is one of the easiest ways to make a first contribution — no code required.
+
+**To document a connector:**
+
+1. **Find one that needs documenting** in the [connector docs tracking issue](https://github.com/fluxturn/fluxturn/issues) (look for the issue tagged `documentation`), or browse [`docs/connectors/README.md`](docs/connectors/README.md) for the full checklist. Comment on the tracking issue to claim a connector before starting.
+
+2. **Read the template** at [`docs/connectors/_template.md`](docs/connectors/_template.md) and at least one of the three reference docs:
+   - [`telegram.md`](docs/connectors/telegram.md) — simple API key auth
+   - [`gmail.md`](docs/connectors/gmail.md) — OAuth2 with polling triggers
+   - [`slack.md`](docs/connectors/slack.md) — Bearer token with webhook (Events API) triggers
+
+3. **Read the connector source** to find real action IDs, trigger IDs, and required fields. The source path follows this pattern:
+   ```
+   backend/src/modules/fluxturn/connectors/<category>/<name>/<name>.connector.ts
+   ```
+   Look at `getMetadata()`, `getActions()`, and `getTriggers()` for the authoritative list of capabilities.
+
+4. **Create your doc file** by copying the template:
+   ```bash
+   cp docs/connectors/_template.md docs/connectors/<connector-name>.md
+   ```
+   Use lowercase, hyphenated names: `google-sheets.md`, not `Google Sheets.md`.
+
+5. **Fill in every section**, deleting the `> ` instructional notes as you go. Don't skip "Common gotchas" — those are the most useful part for users hitting real problems.
+
+6. **Open a PR** against `main` with the title `docs(connectors): add documentation for <Connector>`. One connector per PR keeps reviews fast.
+
+7. **Update the checklist** in the tracking issue (or the maintainer will).
+
+**Tips:**
+- Document only what's actually in the source. If `getActions()` lists 5 actions, your doc should have 5 actions — don't make up features that don't exist.
+- Use placeholder URLs (`https://your-instance.com`) instead of any specific deployment URL.
+- For gotchas, draw on real experience if you've used the service. If you haven't, check the service's official docs and Stack Overflow for the most common pitfalls.
+
 ## Adding Translations
 
 FluxTurn uses [i18next](https://i18next.com) for internationalization.

--- a/docs/connectors/README.md
+++ b/docs/connectors/README.md
@@ -1,0 +1,221 @@
+# Connector documentation
+
+This directory contains per-connector setup guides and reference docs for all 126 connectors that ship with FluxTurn. Each connector gets one markdown file covering:
+
+- Auth setup (where to get credentials)
+- Available actions and their inputs
+- Available triggers (webhook or polling)
+- Common gotchas
+- An example workflow
+
+If a connector has a checkmark below, click through to its doc. If it doesn't, that doc hasn't been written yet — see [Contributing](#contributing) below if you'd like to help.
+
+## Contributing
+
+Documenting a connector is a great first contribution to FluxTurn:
+
+1. **Pick a connector** from the list below that doesn't have a checkmark, or claim one in the [connector docs tracking issue](https://github.com/fluxturn/fluxturn/issues) (look for the issue tagged `documentation`).
+2. **Copy the template:** `cp docs/connectors/_template.md docs/connectors/<connector-name>.md`
+3. **Read the connector source** at `backend/src/modules/fluxturn/connectors/<category>/<name>/<name>.connector.ts` to find real action IDs, trigger IDs, and required fields.
+4. **Fill in the template** following the [Telegram](telegram.md), [Gmail](gmail.md), or [Slack](slack.md) examples for tone and depth.
+5. **Open a PR** against `main`. Each PR should add exactly one connector doc to keep review easy.
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md#documenting-a-connector) for the full guide.
+
+---
+
+## All connectors
+
+### AI (6)
+
+- [ ] Anthropic — `backend/src/modules/fluxturn/connectors/ai/anthropic/`
+- [ ] AWS Bedrock — `backend/src/modules/fluxturn/connectors/ai/aws-bedrock/`
+- [ ] Google AI — `backend/src/modules/fluxturn/connectors/ai/google-ai/`
+- [ ] Google Gemini — `backend/src/modules/fluxturn/connectors/ai/google-gemini/`
+- [ ] OpenAI — `backend/src/modules/fluxturn/connectors/ai/openai/`
+- [ ] OpenAI Chatbot — `backend/src/modules/fluxturn/connectors/ai/openai-chatbot/`
+
+### Analytics (7)
+
+- [ ] Google Analytics — `backend/src/modules/fluxturn/connectors/analytics/google-analytics/`
+- [ ] Grafana — `backend/src/modules/fluxturn/connectors/analytics/grafana/`
+- [ ] Metabase — `backend/src/modules/fluxturn/connectors/analytics/metabase/`
+- [ ] Mixpanel — `backend/src/modules/fluxturn/connectors/analytics/mixpanel/`
+- [ ] PostHog — `backend/src/modules/fluxturn/connectors/analytics/posthog/`
+- [ ] Segment — `backend/src/modules/fluxturn/connectors/analytics/segment/`
+- [ ] Splunk — `backend/src/modules/fluxturn/connectors/analytics/splunk/`
+
+### CMS (5)
+
+- [ ] Contentful — `backend/src/modules/fluxturn/connectors/cms/contentful/`
+- [ ] Ghost — `backend/src/modules/fluxturn/connectors/cms/ghost/`
+- [ ] Medium — `backend/src/modules/fluxturn/connectors/cms/medium/`
+- [ ] Webflow — `backend/src/modules/fluxturn/connectors/cms/webflow/`
+- [ ] WordPress — `backend/src/modules/fluxturn/connectors/cms/wordpress/`
+
+### Communication (16)
+
+- [ ] AWS SES — `backend/src/modules/fluxturn/connectors/communication/aws-ses/`
+- [ ] Calendly — `backend/src/modules/fluxturn/connectors/communication/calendly/`
+- [ ] Discord — `backend/src/modules/fluxturn/connectors/communication/discord/`
+- [ ] Discourse — `backend/src/modules/fluxturn/connectors/communication/discourse/`
+- [x] **[Gmail](gmail.md)** — `backend/src/modules/fluxturn/connectors/communication/gmail/`
+- [ ] Google Calendar — `backend/src/modules/fluxturn/connectors/communication/google-calendar/`
+- [ ] IMAP — `backend/src/modules/fluxturn/connectors/communication/imap/`
+- [ ] Matrix — `backend/src/modules/fluxturn/connectors/communication/matrix/`
+- [ ] Mattermost — `backend/src/modules/fluxturn/connectors/communication/mattermost/`
+- [ ] POP3 — `backend/src/modules/fluxturn/connectors/communication/pop3/`
+- [x] **[Slack](slack.md)** — `backend/src/modules/fluxturn/connectors/communication/slack/`
+- [ ] SMTP — `backend/src/modules/fluxturn/connectors/communication/smtp/`
+- [ ] Microsoft Teams — `backend/src/modules/fluxturn/connectors/communication/teams/`
+- [x] **[Telegram](telegram.md)** — `backend/src/modules/fluxturn/connectors/communication/telegram/`
+- [ ] Twilio — `backend/src/modules/fluxturn/connectors/communication/twilio/`
+- [ ] WhatsApp — `backend/src/modules/fluxturn/connectors/communication/whatsapp/`
+
+### CRM (7)
+
+- [ ] Airtable — `backend/src/modules/fluxturn/connectors/crm/airtable/`
+- [ ] HubSpot — `backend/src/modules/fluxturn/connectors/crm/hubspot/`
+- [ ] Jotform — `backend/src/modules/fluxturn/connectors/crm/jotform/`
+- [ ] Monday.com — `backend/src/modules/fluxturn/connectors/crm/monday/`
+- [ ] Pipedrive — `backend/src/modules/fluxturn/connectors/crm/pipedrive/`
+- [ ] Salesforce — `backend/src/modules/fluxturn/connectors/crm/salesforce/`
+- [ ] Zoho CRM — `backend/src/modules/fluxturn/connectors/crm/zoho/`
+
+### Data Processing (3)
+
+- [ ] Extract From File — `backend/src/modules/fluxturn/connectors/data_processing/extract-from-file/`
+- [ ] Scrapfly — `backend/src/modules/fluxturn/connectors/data_processing/scrapfly/`
+- [ ] Supabase — `backend/src/modules/fluxturn/connectors/data_processing/supabase/`
+
+### Database (1)
+
+- [ ] Elasticsearch — `backend/src/modules/fluxturn/connectors/database/elasticsearch/`
+
+### Development (9)
+
+- [ ] Bitbucket — `backend/src/modules/fluxturn/connectors/development/bitbucket/`
+- [ ] Git — `backend/src/modules/fluxturn/connectors/development/git/`
+- [ ] GitHub — `backend/src/modules/fluxturn/connectors/development/github/`
+- [ ] GitLab — `backend/src/modules/fluxturn/connectors/development/gitlab/`
+- [ ] Jenkins — `backend/src/modules/fluxturn/connectors/development/jenkins/`
+- [ ] n8n — `backend/src/modules/fluxturn/connectors/development/n8n/`
+- [ ] Netlify — `backend/src/modules/fluxturn/connectors/development/netlify/`
+- [ ] npm — `backend/src/modules/fluxturn/connectors/development/npm/`
+- [ ] Travis CI — `backend/src/modules/fluxturn/connectors/development/travis-ci/`
+
+### E-Commerce (8)
+
+- [ ] Gumroad — `backend/src/modules/fluxturn/connectors/ecommerce/gumroad/`
+- [ ] Magento — `backend/src/modules/fluxturn/connectors/ecommerce/magento/`
+- [ ] Paddle — `backend/src/modules/fluxturn/connectors/ecommerce/paddle/`
+- [ ] PayPal — `backend/src/modules/fluxturn/connectors/ecommerce/paypal/`
+- [ ] Shopify — `backend/src/modules/fluxturn/connectors/ecommerce/shopify/`
+- [ ] Stripe — `backend/src/modules/fluxturn/connectors/ecommerce/stripe/`
+- [ ] Stripe v2 — `backend/src/modules/fluxturn/connectors/ecommerce/stripe-v2/`
+- [ ] WooCommerce — `backend/src/modules/fluxturn/connectors/ecommerce/woocommerce/`
+
+### Finance (5)
+
+- [ ] Chargebee — `backend/src/modules/fluxturn/connectors/finance/chargebee/`
+- [ ] Plaid — `backend/src/modules/fluxturn/connectors/finance/plaid/`
+- [ ] QuickBooks — `backend/src/modules/fluxturn/connectors/finance/quickbooks/`
+- [ ] Wise — `backend/src/modules/fluxturn/connectors/finance/wise/`
+- [ ] Xero — `backend/src/modules/fluxturn/connectors/finance/xero/`
+
+### Forms (3)
+
+- [ ] Google Forms — `backend/src/modules/fluxturn/connectors/forms/google-forms/`
+- [ ] Jotform (Forms) — `backend/src/modules/fluxturn/connectors/forms/jotform/`
+- [ ] Typeform — `backend/src/modules/fluxturn/connectors/forms/typeform/`
+
+### Infrastructure (4)
+
+- [ ] Cloudflare — `backend/src/modules/fluxturn/connectors/infrastructure/cloudflare/`
+- [ ] GraphQL — `backend/src/modules/fluxturn/connectors/infrastructure/graphql/`
+- [ ] Kafka — `backend/src/modules/fluxturn/connectors/infrastructure/kafka/`
+- [ ] RabbitMQ — `backend/src/modules/fluxturn/connectors/infrastructure/rabbitmq/`
+
+### Marketing (7)
+
+- [ ] ActiveCampaign — `backend/src/modules/fluxturn/connectors/marketing/activecampaign/`
+- [ ] Brevo — `backend/src/modules/fluxturn/connectors/marketing/brevo/`
+- [ ] Facebook Ads — `backend/src/modules/fluxturn/connectors/marketing/facebook-ads/`
+- [ ] Google Ads — `backend/src/modules/fluxturn/connectors/marketing/google-ads/`
+- [ ] Klaviyo — `backend/src/modules/fluxturn/connectors/marketing/klaviyo/`
+- [ ] Mailchimp — `backend/src/modules/fluxturn/connectors/marketing/mailchimp/`
+- [ ] SendGrid — `backend/src/modules/fluxturn/connectors/marketing/sendgrid/`
+
+### Productivity (6)
+
+- [ ] Clockify — `backend/src/modules/fluxturn/connectors/productivity/clockify/`
+- [ ] Figma — `backend/src/modules/fluxturn/connectors/productivity/figma/`
+- [ ] Harvest — `backend/src/modules/fluxturn/connectors/productivity/harvest/`
+- [ ] Spotify — `backend/src/modules/fluxturn/connectors/productivity/spotify/`
+- [ ] Todoist — `backend/src/modules/fluxturn/connectors/productivity/todoist/`
+- [ ] Toggl — `backend/src/modules/fluxturn/connectors/productivity/toggl/`
+
+### Project Management (6)
+
+- [ ] Asana — `backend/src/modules/fluxturn/connectors/project-management/asana/`
+- [ ] ClickUp — `backend/src/modules/fluxturn/connectors/project-management/clickup/`
+- [ ] Jira — `backend/src/modules/fluxturn/connectors/project-management/jira/`
+- [ ] Linear — `backend/src/modules/fluxturn/connectors/project-management/linear/`
+- [ ] Notion — `backend/src/modules/fluxturn/connectors/project-management/notion/`
+- [ ] Trello — `backend/src/modules/fluxturn/connectors/project-management/trello/`
+
+### Social (9)
+
+- [ ] Facebook — `backend/src/modules/fluxturn/connectors/social/facebook/`
+- [ ] Facebook Graph — `backend/src/modules/fluxturn/connectors/social/facebook-graph/`
+- [ ] Instagram — `backend/src/modules/fluxturn/connectors/social/instagram/`
+- [ ] LinkedIn — `backend/src/modules/fluxturn/connectors/social/linkedin/`
+- [ ] Pinterest — `backend/src/modules/fluxturn/connectors/social/pinterest/`
+- [ ] Reddit — `backend/src/modules/fluxturn/connectors/social/reddit/`
+- [ ] TikTok — `backend/src/modules/fluxturn/connectors/social/tiktok/`
+- [ ] Twitter — `backend/src/modules/fluxturn/connectors/social/twitter/`
+- [ ] YouTube (Social) — `backend/src/modules/fluxturn/connectors/social/youtube/`
+
+### Storage (10)
+
+- [ ] AWS S3 — `backend/src/modules/fluxturn/connectors/storage/aws-s3/`
+- [ ] Dropbox — `backend/src/modules/fluxturn/connectors/storage/dropbox/`
+- [ ] Google Docs — `backend/src/modules/fluxturn/connectors/storage/google-docs/`
+- [ ] Google Drive — `backend/src/modules/fluxturn/connectors/storage/google-drive/`
+- [ ] Google Sheets — `backend/src/modules/fluxturn/connectors/storage/google-sheets/`
+- [ ] MongoDB — `backend/src/modules/fluxturn/connectors/storage/mongodb/`
+- [ ] MySQL — `backend/src/modules/fluxturn/connectors/storage/mysql/`
+- [ ] PostgreSQL — `backend/src/modules/fluxturn/connectors/storage/postgresql/`
+- [ ] Redis — `backend/src/modules/fluxturn/connectors/storage/redis/`
+- [ ] Snowflake — `backend/src/modules/fluxturn/connectors/storage/snowflake/`
+
+### Support (6)
+
+- [ ] Freshdesk — `backend/src/modules/fluxturn/connectors/support/freshdesk/`
+- [ ] Intercom — `backend/src/modules/fluxturn/connectors/support/intercom/`
+- [ ] PagerDuty — `backend/src/modules/fluxturn/connectors/support/pagerduty/`
+- [ ] Sentry — `backend/src/modules/fluxturn/connectors/support/sentry-io/`
+- [ ] ServiceNow — `backend/src/modules/fluxturn/connectors/support/servicenow/`
+- [ ] Zendesk — `backend/src/modules/fluxturn/connectors/support/zendesk/`
+
+### Utility (5)
+
+- [ ] Bitly — `backend/src/modules/fluxturn/connectors/utility/bitly/`
+- [ ] DeepL — `backend/src/modules/fluxturn/connectors/utility/deepl/`
+- [ ] Execute Command — `backend/src/modules/fluxturn/connectors/utility/execute-command/`
+- [ ] FTP — `backend/src/modules/fluxturn/connectors/utility/ftp/`
+- [ ] SSH — `backend/src/modules/fluxturn/connectors/utility/ssh/`
+
+### Video (2)
+
+- [ ] YouTube (Video) — `backend/src/modules/fluxturn/connectors/video/youtube/`
+- [ ] Zoom — `backend/src/modules/fluxturn/connectors/video/zoom/`
+
+---
+
+**Total: 126 connectors • 3 documented • 123 to go**
+
+> Notes:
+> - **Jotform** appears in both `crm/` and `forms/` — they're different implementations of the same service.
+> - **YouTube** appears in both `social/` and `video/` — same situation.
+> - There's also a `connectors/implementations/redis.connector.ts` file alongside `connectors/storage/redis/`. The `storage/redis` one is the user-facing connector; `implementations/redis.connector.ts` is internal infrastructure and doesn't need a doc.

--- a/docs/connectors/_TRACKING_ISSUE_DRAFT.md
+++ b/docs/connectors/_TRACKING_ISSUE_DRAFT.md
@@ -1,0 +1,242 @@
+<!--
+This is a draft of the umbrella tracking issue body. Copy the content below
+(everything after the second `---`) into a new GitHub issue:
+
+  Title:  Connector documentation tracker
+  Labels: documentation, good first issue, help wanted
+
+After creating the issue, delete this file (it's only here so the draft lives
+in the same PR as the docs scaffolding).
+-->
+
+---
+
+## Connector documentation tracker
+
+We're documenting all 126 FluxTurn connectors. Each connector gets one markdown file in [`docs/connectors/`](../../tree/main/docs/connectors).
+
+This is a great first contribution if you've used FluxTurn or one of the underlying services.
+
+## How to claim and contribute
+
+1. **Claim a connector** by commenting on this issue: `I'll take Stripe` (or whichever you want). I'll edit this issue to assign it to you so others know it's taken.
+2. **Read the template** at [`docs/connectors/_template.md`](../blob/main/docs/connectors/_template.md) and the three reference docs to see the expected format and depth:
+   - [`telegram.md`](../blob/main/docs/connectors/telegram.md) — simple API key auth
+   - [`gmail.md`](../blob/main/docs/connectors/gmail.md) — OAuth2 with polling triggers
+   - [`slack.md`](../blob/main/docs/connectors/slack.md) — Bearer token with webhook (Events API) triggers
+3. **Read the connector source** to find real action IDs, trigger IDs, and required fields. The path is in each checklist item below.
+4. **Create your doc:** `cp docs/connectors/_template.md docs/connectors/<connector-name>.md` and fill it in.
+5. **Open a PR against `main`**, one connector per PR. Title format: `docs(connectors): add documentation for <Connector>`.
+6. **Update the checklist** in this issue when your PR merges (or I'll do it).
+
+See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#documenting-a-connector) for the full guide.
+
+## What each doc should contain
+
+Following the template:
+
+- **Header** — category, auth type, webhook support, source path
+- **Overview** — 1-2 sentences about what the service does
+- **Setup** — step-by-step credential creation and connection in FluxTurn
+- **Available actions** — table of every action with descriptions; expand the most-used ones
+- **Available triggers** — table of every trigger with type (webhook/polling) and descriptions
+- **Common gotchas** — things that have actually tripped people up (rate limits, scope issues, sandbox vs prod)
+- **Example workflow** — one realistic workflow using this connector
+- **Links** — official API docs, dev portal, source file
+
+## Checklist
+
+Total: **126 connectors** • **3 documented** • **123 to go**
+
+### AI (6)
+
+- [ ] Anthropic — `backend/src/modules/fluxturn/connectors/ai/anthropic/`
+- [ ] AWS Bedrock — `backend/src/modules/fluxturn/connectors/ai/aws-bedrock/`
+- [ ] Google AI — `backend/src/modules/fluxturn/connectors/ai/google-ai/`
+- [ ] Google Gemini — `backend/src/modules/fluxturn/connectors/ai/google-gemini/`
+- [ ] OpenAI — `backend/src/modules/fluxturn/connectors/ai/openai/`
+- [ ] OpenAI Chatbot — `backend/src/modules/fluxturn/connectors/ai/openai-chatbot/`
+
+### Analytics (7)
+
+- [ ] Google Analytics — `backend/src/modules/fluxturn/connectors/analytics/google-analytics/`
+- [ ] Grafana — `backend/src/modules/fluxturn/connectors/analytics/grafana/`
+- [ ] Metabase — `backend/src/modules/fluxturn/connectors/analytics/metabase/`
+- [ ] Mixpanel — `backend/src/modules/fluxturn/connectors/analytics/mixpanel/`
+- [ ] PostHog — `backend/src/modules/fluxturn/connectors/analytics/posthog/`
+- [ ] Segment — `backend/src/modules/fluxturn/connectors/analytics/segment/`
+- [ ] Splunk — `backend/src/modules/fluxturn/connectors/analytics/splunk/`
+
+### CMS (5)
+
+- [ ] Contentful — `backend/src/modules/fluxturn/connectors/cms/contentful/`
+- [ ] Ghost — `backend/src/modules/fluxturn/connectors/cms/ghost/`
+- [ ] Medium — `backend/src/modules/fluxturn/connectors/cms/medium/`
+- [ ] Webflow — `backend/src/modules/fluxturn/connectors/cms/webflow/`
+- [ ] WordPress — `backend/src/modules/fluxturn/connectors/cms/wordpress/`
+
+### Communication (16)
+
+- [ ] AWS SES — `backend/src/modules/fluxturn/connectors/communication/aws-ses/`
+- [ ] Calendly — `backend/src/modules/fluxturn/connectors/communication/calendly/`
+- [ ] Discord — `backend/src/modules/fluxturn/connectors/communication/discord/`
+- [ ] Discourse — `backend/src/modules/fluxturn/connectors/communication/discourse/`
+- [x] Gmail — done in [`docs/connectors/gmail.md`](../blob/main/docs/connectors/gmail.md)
+- [ ] Google Calendar — `backend/src/modules/fluxturn/connectors/communication/google-calendar/`
+- [ ] IMAP — `backend/src/modules/fluxturn/connectors/communication/imap/`
+- [ ] Matrix — `backend/src/modules/fluxturn/connectors/communication/matrix/`
+- [ ] Mattermost — `backend/src/modules/fluxturn/connectors/communication/mattermost/`
+- [ ] POP3 — `backend/src/modules/fluxturn/connectors/communication/pop3/`
+- [x] Slack — done in [`docs/connectors/slack.md`](../blob/main/docs/connectors/slack.md)
+- [ ] SMTP — `backend/src/modules/fluxturn/connectors/communication/smtp/`
+- [ ] Microsoft Teams — `backend/src/modules/fluxturn/connectors/communication/teams/`
+- [x] Telegram — done in [`docs/connectors/telegram.md`](../blob/main/docs/connectors/telegram.md)
+- [ ] Twilio — `backend/src/modules/fluxturn/connectors/communication/twilio/`
+- [ ] WhatsApp — `backend/src/modules/fluxturn/connectors/communication/whatsapp/`
+
+### CRM (7)
+
+- [ ] Airtable — `backend/src/modules/fluxturn/connectors/crm/airtable/`
+- [ ] HubSpot — `backend/src/modules/fluxturn/connectors/crm/hubspot/`
+- [ ] Jotform (CRM) — `backend/src/modules/fluxturn/connectors/crm/jotform/`
+- [ ] Monday.com — `backend/src/modules/fluxturn/connectors/crm/monday/`
+- [ ] Pipedrive — `backend/src/modules/fluxturn/connectors/crm/pipedrive/`
+- [ ] Salesforce — `backend/src/modules/fluxturn/connectors/crm/salesforce/`
+- [ ] Zoho CRM — `backend/src/modules/fluxturn/connectors/crm/zoho/`
+
+### Data Processing (3)
+
+- [ ] Extract From File — `backend/src/modules/fluxturn/connectors/data_processing/extract-from-file/`
+- [ ] Scrapfly — `backend/src/modules/fluxturn/connectors/data_processing/scrapfly/`
+- [ ] Supabase — `backend/src/modules/fluxturn/connectors/data_processing/supabase/`
+
+### Database (1)
+
+- [ ] Elasticsearch — `backend/src/modules/fluxturn/connectors/database/elasticsearch/`
+
+### Development (9)
+
+- [ ] Bitbucket — `backend/src/modules/fluxturn/connectors/development/bitbucket/`
+- [ ] Git — `backend/src/modules/fluxturn/connectors/development/git/`
+- [ ] GitHub — `backend/src/modules/fluxturn/connectors/development/github/`
+- [ ] GitLab — `backend/src/modules/fluxturn/connectors/development/gitlab/`
+- [ ] Jenkins — `backend/src/modules/fluxturn/connectors/development/jenkins/`
+- [ ] n8n — `backend/src/modules/fluxturn/connectors/development/n8n/`
+- [ ] Netlify — `backend/src/modules/fluxturn/connectors/development/netlify/`
+- [ ] npm — `backend/src/modules/fluxturn/connectors/development/npm/`
+- [ ] Travis CI — `backend/src/modules/fluxturn/connectors/development/travis-ci/`
+
+### E-Commerce (8)
+
+- [ ] Gumroad — `backend/src/modules/fluxturn/connectors/ecommerce/gumroad/`
+- [ ] Magento — `backend/src/modules/fluxturn/connectors/ecommerce/magento/`
+- [ ] Paddle — `backend/src/modules/fluxturn/connectors/ecommerce/paddle/`
+- [ ] PayPal — `backend/src/modules/fluxturn/connectors/ecommerce/paypal/`
+- [ ] Shopify — `backend/src/modules/fluxturn/connectors/ecommerce/shopify/`
+- [ ] Stripe — `backend/src/modules/fluxturn/connectors/ecommerce/stripe/`
+- [ ] Stripe v2 — `backend/src/modules/fluxturn/connectors/ecommerce/stripe-v2/`
+- [ ] WooCommerce — `backend/src/modules/fluxturn/connectors/ecommerce/woocommerce/`
+
+### Finance (5)
+
+- [ ] Chargebee — `backend/src/modules/fluxturn/connectors/finance/chargebee/`
+- [ ] Plaid — `backend/src/modules/fluxturn/connectors/finance/plaid/`
+- [ ] QuickBooks — `backend/src/modules/fluxturn/connectors/finance/quickbooks/`
+- [ ] Wise — `backend/src/modules/fluxturn/connectors/finance/wise/`
+- [ ] Xero — `backend/src/modules/fluxturn/connectors/finance/xero/`
+
+### Forms (3)
+
+- [ ] Google Forms — `backend/src/modules/fluxturn/connectors/forms/google-forms/`
+- [ ] Jotform (Forms) — `backend/src/modules/fluxturn/connectors/forms/jotform/`
+- [ ] Typeform — `backend/src/modules/fluxturn/connectors/forms/typeform/`
+
+### Infrastructure (4)
+
+- [ ] Cloudflare — `backend/src/modules/fluxturn/connectors/infrastructure/cloudflare/`
+- [ ] GraphQL — `backend/src/modules/fluxturn/connectors/infrastructure/graphql/`
+- [ ] Kafka — `backend/src/modules/fluxturn/connectors/infrastructure/kafka/`
+- [ ] RabbitMQ — `backend/src/modules/fluxturn/connectors/infrastructure/rabbitmq/`
+
+### Marketing (7)
+
+- [ ] ActiveCampaign — `backend/src/modules/fluxturn/connectors/marketing/activecampaign/`
+- [ ] Brevo — `backend/src/modules/fluxturn/connectors/marketing/brevo/`
+- [ ] Facebook Ads — `backend/src/modules/fluxturn/connectors/marketing/facebook-ads/`
+- [ ] Google Ads — `backend/src/modules/fluxturn/connectors/marketing/google-ads/`
+- [ ] Klaviyo — `backend/src/modules/fluxturn/connectors/marketing/klaviyo/`
+- [ ] Mailchimp — `backend/src/modules/fluxturn/connectors/marketing/mailchimp/`
+- [ ] SendGrid — `backend/src/modules/fluxturn/connectors/marketing/sendgrid/`
+
+### Productivity (6)
+
+- [ ] Clockify — `backend/src/modules/fluxturn/connectors/productivity/clockify/`
+- [ ] Figma — `backend/src/modules/fluxturn/connectors/productivity/figma/`
+- [ ] Harvest — `backend/src/modules/fluxturn/connectors/productivity/harvest/`
+- [ ] Spotify — `backend/src/modules/fluxturn/connectors/productivity/spotify/`
+- [ ] Todoist — `backend/src/modules/fluxturn/connectors/productivity/todoist/`
+- [ ] Toggl — `backend/src/modules/fluxturn/connectors/productivity/toggl/`
+
+### Project Management (6)
+
+- [ ] Asana — `backend/src/modules/fluxturn/connectors/project-management/asana/`
+- [ ] ClickUp — `backend/src/modules/fluxturn/connectors/project-management/clickup/`
+- [ ] Jira — `backend/src/modules/fluxturn/connectors/project-management/jira/`
+- [ ] Linear — `backend/src/modules/fluxturn/connectors/project-management/linear/`
+- [ ] Notion — `backend/src/modules/fluxturn/connectors/project-management/notion/`
+- [ ] Trello — `backend/src/modules/fluxturn/connectors/project-management/trello/`
+
+### Social (9)
+
+- [ ] Facebook — `backend/src/modules/fluxturn/connectors/social/facebook/`
+- [ ] Facebook Graph — `backend/src/modules/fluxturn/connectors/social/facebook-graph/`
+- [ ] Instagram — `backend/src/modules/fluxturn/connectors/social/instagram/`
+- [ ] LinkedIn — `backend/src/modules/fluxturn/connectors/social/linkedin/`
+- [ ] Pinterest — `backend/src/modules/fluxturn/connectors/social/pinterest/`
+- [ ] Reddit — `backend/src/modules/fluxturn/connectors/social/reddit/`
+- [ ] TikTok — `backend/src/modules/fluxturn/connectors/social/tiktok/`
+- [ ] Twitter — `backend/src/modules/fluxturn/connectors/social/twitter/`
+- [ ] YouTube (Social) — `backend/src/modules/fluxturn/connectors/social/youtube/`
+
+### Storage (10)
+
+- [ ] AWS S3 — `backend/src/modules/fluxturn/connectors/storage/aws-s3/`
+- [ ] Dropbox — `backend/src/modules/fluxturn/connectors/storage/dropbox/`
+- [ ] Google Docs — `backend/src/modules/fluxturn/connectors/storage/google-docs/`
+- [ ] Google Drive — `backend/src/modules/fluxturn/connectors/storage/google-drive/`
+- [ ] Google Sheets — `backend/src/modules/fluxturn/connectors/storage/google-sheets/`
+- [ ] MongoDB — `backend/src/modules/fluxturn/connectors/storage/mongodb/`
+- [ ] MySQL — `backend/src/modules/fluxturn/connectors/storage/mysql/`
+- [ ] PostgreSQL — `backend/src/modules/fluxturn/connectors/storage/postgresql/`
+- [ ] Redis — `backend/src/modules/fluxturn/connectors/storage/redis/`
+- [ ] Snowflake — `backend/src/modules/fluxturn/connectors/storage/snowflake/`
+
+### Support (6)
+
+- [ ] Freshdesk — `backend/src/modules/fluxturn/connectors/support/freshdesk/`
+- [ ] Intercom — `backend/src/modules/fluxturn/connectors/support/intercom/`
+- [ ] PagerDuty — `backend/src/modules/fluxturn/connectors/support/pagerduty/`
+- [ ] Sentry — `backend/src/modules/fluxturn/connectors/support/sentry-io/`
+- [ ] ServiceNow — `backend/src/modules/fluxturn/connectors/support/servicenow/`
+- [ ] Zendesk — `backend/src/modules/fluxturn/connectors/support/zendesk/`
+
+### Utility (5)
+
+- [ ] Bitly — `backend/src/modules/fluxturn/connectors/utility/bitly/`
+- [ ] DeepL — `backend/src/modules/fluxturn/connectors/utility/deepl/`
+- [ ] Execute Command — `backend/src/modules/fluxturn/connectors/utility/execute-command/`
+- [ ] FTP — `backend/src/modules/fluxturn/connectors/utility/ftp/`
+- [ ] SSH — `backend/src/modules/fluxturn/connectors/utility/ssh/`
+
+### Video (2)
+
+- [ ] YouTube (Video) — `backend/src/modules/fluxturn/connectors/video/youtube/`
+- [ ] Zoom — `backend/src/modules/fluxturn/connectors/video/zoom/`
+
+---
+
+**Notes:**
+- Jotform appears in both `crm/` and `forms/` — they're separate implementations of the same service. Both need docs.
+- YouTube appears in both `social/` and `video/` — same situation.
+
+Thanks for helping document FluxTurn! Every doc makes the platform easier to use.

--- a/docs/connectors/_template.md
+++ b/docs/connectors/_template.md
@@ -1,0 +1,109 @@
+# {Connector Name}
+
+> Replace `{Connector Name}` and the rest of the placeholders below.
+> When you're done, delete this blockquote and the `> ` notes that follow each section.
+> See `telegram.md`, `gmail.md`, or `slack.md` for completed examples.
+
+**Category:** {ai | analytics | cms | communication | crm | data_processing | database | development | ecommerce | finance | forms | infrastructure | marketing | productivity | project-management | social | storage | support | utility | video}
+**Auth type:** {API Key | OAuth2 | Bearer Token | Basic Auth}
+**Webhook support:** {Yes | No}
+**Source:** [`backend/src/modules/fluxturn/connectors/{category}/{name}/{name}.connector.ts`](../../backend/src/modules/fluxturn/connectors/{category}/{name}/{name}.connector.ts)
+
+---
+
+## Overview
+
+> One or two sentences explaining what this service is and what FluxTurn workflows can do with it. Keep it short — the action/trigger lists below carry the detail.
+
+## Setup
+
+> Step-by-step instructions for getting credentials from the third-party service and connecting them in FluxTurn.
+
+1. **Get your credentials from {Service}**
+   - Sign in to the {Service} dashboard
+   - Navigate to {API/Developer/Settings} → {Credentials/API Keys/Apps}
+   - {Specific instructions: create an app, copy a token, etc.}
+
+2. **Add the credential in FluxTurn**
+   - Open FluxTurn at `http://localhost:5185` (or your deployment URL)
+   - Go to **Credentials** → **Add Credential**
+   - Select **{Connector Name}** from the list
+   - Paste your {token / API key / OAuth flow} and click **Test Connection**
+   - Give the credential a name and save
+
+3. **Use it in a workflow**
+   - In the workflow editor, add a node and search for **{Connector Name}**
+   - Pick the action or trigger you want
+   - Select your saved credential from the dropdown
+
+## Available actions
+
+> List every action exposed by the connector. The action `id` values come from `getActions()` in the connector source file.
+
+| Action ID | Name | Description |
+|---|---|---|
+| `action_id_1` | Action Name | What it does in one line |
+| `action_id_2` | Action Name | What it does in one line |
+
+### `action_id_1` — Action Name
+
+> Optional: expand on actions that need more explanation. Document required vs optional fields.
+
+**Inputs:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `field1` | string | yes | What this field is |
+| `field2` | number | no | What this field is |
+
+**Output:** Brief description of what the action returns.
+
+## Available triggers
+
+> List every trigger from `getTriggers()`. Note whether each is webhook-based, polling-based, or both.
+
+| Trigger ID | Name | Type | Description |
+|---|---|---|---|
+| `trigger_id_1` | Trigger Name | Webhook | When the workflow fires |
+| `trigger_id_2` | Trigger Name | Polling | When the workflow fires |
+
+### `trigger_id_1` — Trigger Name
+
+> Expand on triggers if needed. For webhook triggers, mention whether FluxTurn auto-registers the webhook or whether the user has to set it up manually in the third-party service.
+
+**Output payload:**
+
+| Field | Type | Description |
+|---|---|---|
+| `field1` | string | What it contains |
+
+## Common gotchas
+
+> Things that have tripped people up. Examples:
+> - Sandbox vs production credentials use different URLs
+> - Rate limits and how to avoid them
+> - Permissions/scopes that aren't obvious
+> - Common error messages and what they mean
+
+- **{Gotcha 1}:** Explanation and workaround.
+- **{Gotcha 2}:** Explanation and workaround.
+
+## Example workflow
+
+> One realistic workflow using this connector. Describe the trigger, the actions, and what data flows between them. Use the same expression syntax as the rest of the docs (`{{$json.field}}`).
+
+**Goal:** {What this workflow accomplishes in plain English}
+
+**Nodes:**
+
+1. **{Trigger Name}** ({Connector Name} trigger)
+   - {Configuration details}
+2. **{Action 1}** ({Connector Name} action)
+   - Input: `{{$json.field}}`
+3. **{Action 2}** (some other connector or built-in node)
+   - Input: `{{$node["Step 1"].json.field}}`
+
+## Links
+
+- [Official {Service} API documentation]({url})
+- [FluxTurn connector source](../../backend/src/modules/fluxturn/connectors/{category}/{name}/{name}.connector.ts)

--- a/docs/connectors/gmail.md
+++ b/docs/connectors/gmail.md
@@ -1,0 +1,155 @@
+# Gmail
+
+**Category:** communication
+**Auth type:** OAuth2 (Google)
+**Webhook support:** Yes (push notifications via polling fallback)
+**Source:** [`backend/src/modules/fluxturn/connectors/communication/gmail/gmail.connector.ts`](../../backend/src/modules/fluxturn/connectors/communication/gmail/gmail.connector.ts)
+
+---
+
+## Overview
+
+Send, read, search, label, and manage emails through a Gmail account using the [Gmail API](https://developers.google.com/gmail/api). Supports both interactive workflows ("send a follow-up when X happens") and automated email processing ("when an email matching this filter arrives, do Y").
+
+## Setup
+
+1. **Create a Google Cloud OAuth client**
+   - Go to the [Google Cloud Console](https://console.cloud.google.com/) and create a project (or pick an existing one)
+   - Enable the **Gmail API**: APIs & Services → Library → search "Gmail API" → Enable
+   - Go to **APIs & Services → Credentials** → **Create Credentials** → **OAuth client ID**
+   - Application type: **Web application**
+   - Authorized redirect URIs: `http://localhost:5005/api/v1/oauth/google/callback` (for local dev — use your production URL otherwise)
+   - Copy the **Client ID** and **Client Secret**
+
+2. **Configure FluxTurn's Google OAuth credentials**
+   - Add the values to your `backend/.env` file:
+     ```
+     GOOGLE_OAUTH_CLIENT_ID=your-client-id
+     GOOGLE_OAUTH_CLIENT_SECRET=your-client-secret
+     GOOGLE_OAUTH_REDIRECT_URI=http://localhost:5005/api/v1/oauth/google/callback
+     ```
+   - Restart the backend so the new env vars are picked up
+
+3. **Connect your Gmail account**
+   - In FluxTurn, go to **Credentials** → **Add Credential** → **Gmail**
+   - Click **Connect with Google** — a popup opens with the Google consent screen
+   - Sign in and grant the requested scopes (compose, read, modify, labels)
+   - The popup closes, the credential is saved with refresh tokens, and you're done
+
+## Available actions
+
+| Action ID | Name | Description |
+|---|---|---|
+| `send_email` | Send Email | Send a new email (plain text or HTML, with optional CC/BCC and attachments) |
+| `get_emails` | Get Emails | Retrieve emails from the inbox with optional filters |
+| `create_draft` | Create Draft | Create an email draft without sending |
+| `add_label` | Add Label | Add one or more labels to a specific email |
+| `search_emails` | Search Emails | Search using [Gmail search syntax](https://support.google.com/mail/answer/7190) |
+| `delete_email` | Delete Email | Permanently delete an email |
+| `mark_as_read` | Mark as Read | Mark a specific email as read |
+
+### `send_email` — Send Email
+
+**Inputs:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `to` | array of strings | yes | Recipient email addresses |
+| `subject` | string | yes | Email subject line |
+| `body` | string | yes | Email body content |
+| `isHtml` | boolean | no | Set true to send `body` as HTML; default is plain text |
+| `cc` | array of strings | no | CC recipients |
+| `bcc` | array of strings | no | BCC recipients |
+| `attachments` | array | no | Attachment objects (filename + content) |
+
+**Output:** `{ messageId, threadId }` of the sent message.
+
+### `search_emails` — Search Emails
+
+**Inputs:** A `searchOptions` object with a Gmail query string. Examples:
+
+| Query | What it matches |
+|---|---|
+| `from:alice@example.com is:unread` | Unread mail from Alice |
+| `subject:invoice has:attachment newer_than:7d` | Recent invoices with attachments |
+| `label:important to:me` | Important mail to you |
+
+**Output:** `{ messages: [...] }` — array of matching email metadata.
+
+## Available triggers
+
+| Trigger ID | Name | Type | Description |
+|---|---|---|---|
+| `email_received` | Email Received | Polling | Fires when a new email arrives matching the filters |
+| `email_sent` | Email Sent | Polling | Fires when you send an email from your account |
+
+### `email_received` — Email Received
+
+This is a **polling trigger**. Gmail's push notifications API requires Pub/Sub setup which is heavyweight, so FluxTurn polls the Gmail API on a configurable interval.
+
+**Inputs:**
+
+| Field | Type | Description |
+|---|---|---|
+| `readStatus` | enum | `all`, `unread`, or `read` (default: `all`) |
+| `sender` | string | Filter by sender email address |
+| `labelIds` | array | Only fire for emails with these Gmail labels (`INBOX`, `IMPORTANT`, etc.) |
+| `searchQuery` | string | Custom Gmail search query (uses Gmail search syntax) |
+| `includeSpamTrash` | boolean | Include emails from Spam and Trash (default: false) |
+| `pollingInterval` | enum | How often to check: `1`, `5`, `15`, `30`, or `60` minutes (default: 5) |
+| `simple` | boolean | If true, returns metadata only (faster); if false, includes full payload (default: true) |
+
+**Output payload:**
+
+| Field | Type | Description |
+|---|---|---|
+| `messageId` | string | Gmail message ID |
+| `threadId` | string | Gmail thread ID |
+| `from` | string | Sender email address |
+| `to` | string | Recipient address(es) |
+| `subject` | string | Email subject |
+| `snippet` | string | Short preview text |
+| `date` | string | Email date |
+| `labelIds` | array | Gmail labels applied |
+| `headers` | object | Full email headers |
+| `payload` | object | Full email payload (only if `simple: false`) |
+
+## Common gotchas
+
+- **OAuth scopes are sticky.** If you initially connect with limited scopes and later add an action that needs more, you'll get a `403 insufficient permission` error. Re-authorize the credential to grant the new scopes.
+- **Polling delay.** The `email_received` trigger has a minimum 1-minute interval, and the actual delay between an email arriving and the trigger firing is up to `pollingInterval + 60s`. For real-time delivery you'd need Gmail push notifications via Google Pub/Sub, which isn't currently supported.
+- **Sending limits.** Gmail's free account allows ~500 sends/day; Workspace accounts allow ~2000/day. Hitting the limit returns `429 Too Many Requests` and the account is temporarily blocked from sending.
+- **`From` address.** Emails are sent from the authenticated account's primary address. To send from an alias, configure it in Gmail Settings → Send mail as.
+- **Attachment size.** Gmail's API limits messages to 25 MB total (including attachments). Larger files need to be uploaded to Drive and shared via link.
+- **HTML body needs `isHtml: true`.** If your `body` contains HTML tags but `isHtml` is false, recipients will see the raw HTML as text.
+- **Search query escaping.** Gmail search syntax uses spaces as AND. To search for a phrase, wrap it in quotes: `subject:"weekly report"`.
+- **`labelIds`, not label names.** When filtering by label, use the system label IDs (`INBOX`, `IMPORTANT`, `STARRED`, etc.) or the IDs of custom labels (which look like `Label_1234567890`). Get them via `get_labels` if needed.
+
+## Example workflow
+
+**Goal:** When an invoice email arrives, save the PDF attachment to Google Drive and notify a Slack channel.
+
+**Nodes:**
+
+1. **Gmail - Email Received** (Gmail trigger)
+   - Search query: `subject:invoice has:attachment newer_than:1d`
+   - Polling interval: `5` minutes
+   - Simple: `false` (we need the full payload to access attachments)
+
+2. **Google Drive - Upload File** (Google Drive action)
+   - File name: `{{$json.subject}}.pdf`
+   - Content: from `{{$json.payload.parts[0].body.data}}` (base64 attachment)
+   - Folder: `Invoices/2026`
+
+3. **Slack - Send Message** (Slack action)
+   - Channel: `#finance`
+   - Text: `New invoice from {{$json.from}}: {{$json.subject}}\nSaved to Drive: {{$node["Google Drive - Upload File"].json.webViewLink}}`
+
+When activated, the workflow polls Gmail every 5 minutes for invoice emails, uploads the attachment to Drive, and posts a Slack notification with a link.
+
+## Links
+
+- [Gmail API documentation](https://developers.google.com/gmail/api)
+- [Gmail search operators](https://support.google.com/mail/answer/7190)
+- [Google Cloud Console](https://console.cloud.google.com/)
+- [FluxTurn connector source](../../backend/src/modules/fluxturn/connectors/communication/gmail/gmail.connector.ts)

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -1,0 +1,156 @@
+# Slack
+
+**Category:** communication
+**Auth type:** Bearer Token (Slack OAuth)
+**Webhook support:** Yes (Events API)
+**Source:** [`backend/src/modules/fluxturn/connectors/communication/slack/slack.connector.ts`](../../backend/src/modules/fluxturn/connectors/communication/slack/slack.connector.ts)
+
+---
+
+## Overview
+
+Send and manage Slack messages, channels, files, and reactions. Reacts to incoming Slack events (messages, mentions, reactions, file uploads) via the [Slack Events API](https://api.slack.com/apis/connections/events-api). Authenticated as a [Slack app](https://api.slack.com/apps) with bot token scopes.
+
+## Setup
+
+1. **Create a Slack app**
+   - Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From scratch**
+   - Name your app and pick a workspace to install it in
+   - Under **OAuth & Permissions**, add the following **Bot Token Scopes**:
+     - `chat:write`, `chat:write.customize` — send messages
+     - `channels:read`, `channels:manage`, `channels:history` — public channels
+     - `groups:read`, `groups:history` — private channels
+     - `im:read`, `im:write`, `im:history` — DMs
+     - `mpim:read`, `mpim:history` — group DMs
+     - `users:read` — user lookups
+     - `app_mentions:read` — `@mention` triggers
+     - `reactions:read` — reaction triggers
+     - `files:read` — file triggers
+   - These are the scopes the connector requests; you can omit any you don't need, but the matching actions/triggers will fail.
+
+2. **Install the app to your workspace**
+   - Still in **OAuth & Permissions**, click **Install to Workspace**
+   - Slack will show the requested scopes and ask for approval
+   - After install, copy the **Bot User OAuth Token** (starts with `xoxb-`)
+
+3. **Add the credential in FluxTurn**
+   - Go to **Credentials** → **Add Credential** → **Slack**
+   - Paste the `xoxb-` token in the **Bearer Token** field
+   - Click **Test Connection** — FluxTurn calls Slack's `auth.test` endpoint to verify
+   - Save
+
+4. **For triggers, configure the Events API**
+   - Back in your Slack app settings, go to **Event Subscriptions** → enable
+   - Request URL: `https://your-instance.com/api/v1/connectors/webhook/slack/<trigger-id>` (FluxTurn shows you the exact URL when you create a workflow with a Slack trigger)
+   - Subscribe to the bot events that match the triggers you want (`message.channels`, `app_mention`, `reaction_added`, etc.)
+   - Reinstall the app if Slack prompts you
+
+## Available actions
+
+| Action ID | Name | Description |
+|---|---|---|
+| `send_message` | Send Message | Post a message to a channel, DM, or thread |
+| `update_message` | Update Message | Edit a previously-sent message |
+| `delete_message` | Delete Message | Delete a message by timestamp |
+| `get_permalink` | Get Permalink | Get a permanent link to a message |
+| `search_messages` | Search Messages | Search workspace messages |
+| `create_channel` | Create Channel | Create a new public or private channel |
+| `get_channel` | Get Channel | Get a channel's metadata by ID |
+| `get_channels` | Get Channels | List channels in the workspace |
+| `channel_history` | Channel History | Fetch messages from a channel |
+| `invite_to_channel` | Invite to Channel | Invite a user to a channel |
+| `join_channel` | Join Channel | Have the bot join a channel |
+| `leave_channel` | Leave Channel | Have the bot leave a channel |
+| `get_channel_members` | Get Channel Members | List members of a channel |
+| `upload_file` | Upload File | Upload a file to Slack |
+| `get_file` | Get File | Get a file's metadata by ID |
+| `get_users` | Get Users | List workspace users |
+| `get_messages` | Get Messages | Get messages by timestamp range |
+
+### `send_message` — Send Message
+
+The most-used action. Posts a message as the bot to a channel, group, DM, or thread.
+
+**Inputs (most common):**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `channel` | string | yes | Channel ID (`C123456`) or name (`#general`) |
+| `text` | string | yes* | Plain-text message body |
+| `blocks` | array | no | [Block Kit](https://api.slack.com/block-kit) JSON for rich formatting |
+| `thread_ts` | string | no | Timestamp of the parent message to reply in a thread |
+| `unfurl_links` | boolean | no | Whether to unfurl URLs in the message |
+
+*Either `text` or `blocks` is required.
+
+## Available triggers
+
+| Trigger ID | Name | Type | Description |
+|---|---|---|---|
+| `message` | Message | Webhook | Fires on any message in a channel the bot can see |
+| `app_mention` | App Mention | Webhook | Fires when someone `@mentions` the bot |
+| `reaction_added` | Reaction Added | Webhook | Fires when someone adds an emoji reaction |
+| `channel_created` | Channel Created | Webhook | Fires when a new channel is created |
+| `team_join` | Team Join | Webhook | Fires when a new user joins the workspace |
+| `file_shared` | File Shared | Webhook | Fires when a file is shared |
+| `file_public` | File Made Public | Webhook | Fires when a file is made publicly accessible |
+
+All Slack triggers are **webhook-based** via the Events API. Slack pushes events to your FluxTurn instance — you must have the Events API URL configured in your Slack app settings (see Setup step 4).
+
+### `app_mention` — App Mention
+
+The "Slack-native" way to build a bot. Fires only when someone explicitly `@mentions` the bot in a channel it's a member of, so it's much quieter than the broad `message` trigger.
+
+**Output payload:**
+
+| Field | Type | Description |
+|---|---|---|
+| `text` | string | The message text (including the `@bot` mention) |
+| `user` | string | User ID of who mentioned the bot |
+| `channel` | string | Channel ID where the mention happened |
+| `ts` | string | Timestamp of the mention (use as `thread_ts` to reply in thread) |
+
+## Common gotchas
+
+- **Bot must be in the channel.** A bot can only post to channels it's been invited to. Use `join_channel` or invite the bot manually with `/invite @YourBotName` in Slack.
+- **`channel` field accepts ID or name.** Channel IDs (`C0123456789`) are more reliable than names (`#general`) because names can change. Use `get_channels` to look up IDs.
+- **Threading.** To reply in a thread, set `thread_ts` to the parent message's `ts`. Without it, your reply posts as a new top-level message in the channel.
+- **Block Kit vs text.** If you use `blocks`, the `text` field is used as a fallback for notifications and screen readers. Provide both for accessibility.
+- **Rate limits.** Slack's API has tier-based rate limits — `chat.postMessage` is Tier 4 (~50/minute). The connector enforces `requestsPerMinute: 50` to stay safe. Bursting will hit `ratelimited` errors.
+- **Events API URL must be HTTPS.** Slack only delivers events to verified HTTPS endpoints with valid certificates. For local development, use ngrok or cloudflared and configure the public URL in your Slack app settings.
+- **Slack verifies the URL on save.** When you set the Events API URL in your app config, Slack sends a one-time `url_verification` challenge that FluxTurn responds to automatically — but only if the workflow is **active** at the moment Slack verifies. Activate the workflow first, then save the URL in Slack.
+- **Scopes are sticky.** If you change scopes after installing the app, you must reinstall it (Slack will prompt). The token won't auto-update.
+- **DMs need different scopes.** To send messages to a DM, you need `im:write` and you must use the user ID (`U0123456789`) as the channel, not the user's name.
+
+## Example workflow
+
+**Goal:** When someone `@mentions` the bot in any channel, classify the message with OpenAI and reply in-thread with the answer.
+
+**Nodes:**
+
+1. **Slack - App Mention** (Slack trigger)
+   - Subscribe to the `app_mention` event in your Slack app settings
+
+2. **OpenAI - Create Chat Completion** (OpenAI action)
+   - Model: `gpt-4o-mini`
+   - Messages:
+     ```json
+     [
+       {"role": "system", "content": "You are a helpful assistant. Reply in 1-2 sentences."},
+       {"role": "user", "content": "{{$json.text}}"}
+     ]
+     ```
+
+3. **Slack - Send Message** (Slack action)
+   - Channel: `{{$json.channel}}`
+   - Text: `{{$node["OpenAI - Create Chat Completion"].json.choices[0].message.content}}`
+   - Thread TS: `{{$json.ts}}` ← this makes it reply in the same thread
+
+When activated, every `@bot` mention in any channel the bot is in gets a threaded GPT-4o-mini reply.
+
+## Links
+
+- [Slack API documentation](https://api.slack.com/)
+- [Block Kit Builder](https://app.slack.com/block-kit-builder) (visual editor for rich messages)
+- [Slack OAuth scopes reference](https://api.slack.com/scopes)
+- [FluxTurn connector source](../../backend/src/modules/fluxturn/connectors/communication/slack/slack.connector.ts)

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -1,0 +1,121 @@
+# Telegram
+
+**Category:** communication
+**Auth type:** API Key (Bot Token)
+**Webhook support:** Yes
+**Source:** [`backend/src/modules/fluxturn/connectors/communication/telegram/telegram.connector.ts`](../../backend/src/modules/fluxturn/connectors/communication/telegram/telegram.connector.ts)
+
+---
+
+## Overview
+
+Send messages and photos through Telegram bots, and receive incoming messages as workflow triggers. Uses the [Telegram Bot API](https://core.telegram.org/bots/api), so you'll need a bot — not a regular Telegram account.
+
+## Setup
+
+1. **Create a Telegram bot**
+   - Open Telegram and start a chat with [@BotFather](https://t.me/botfather)
+   - Send `/newbot` and follow the prompts (you'll choose a display name and a username ending in `bot`)
+   - BotFather will reply with a **bot token** that looks like `123456789:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`
+   - Copy that token — it's the only credential you need
+
+2. **Add the credential in FluxTurn**
+   - Open FluxTurn at `http://localhost:5185` (or your deployment URL)
+   - Go to **Credentials** → **Add Credential**
+   - Select **Telegram** from the list
+   - Paste your bot token in the **Bot Token** field and click **Test Connection**
+   - FluxTurn calls Telegram's `getMe` endpoint to verify the token
+   - Save the credential
+
+3. **Find a chat ID to send messages to**
+   - Telegram requires the recipient (user, group, or channel) to message your bot first, OR
+   - Add the bot to a group/channel as an admin
+   - Forward any message from the chat to [@RawDataBot](https://t.me/RawDataBot) to get the numeric chat ID
+   - For channels, the chat ID looks like `-1001234567890`
+
+## Available actions
+
+| Action ID | Name | Description |
+|---|---|---|
+| `send_message` | Send Message | Send a text message to a chat |
+| `send_photo` | Send Photo | Send a photo (by URL) to a chat with optional caption |
+
+### `send_message` — Send Message
+
+**Inputs:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `chatId` | string | yes | Numeric chat ID, or `@channelusername` for public channels |
+| `text` | string | yes | Message body (up to 4096 characters) |
+| `parseMode` | enum | no | `Markdown` or `HTML` for formatted text. Leave empty for plain text. |
+| `disableNotification` | boolean | no | If true, sends silently (no notification sound) |
+
+**Output:** A Telegram `Message` object including `message_id`, `date`, `chat`, and the sent text.
+
+### `send_photo` — Send Photo
+
+**Inputs:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `chatId` | string | yes | Numeric chat ID or channel username |
+| `photo` | string | yes | Public URL of the photo (or a file_id from a previously-sent photo) |
+| `caption` | string | no | Optional caption (up to 1024 characters) |
+| `parseMode` | enum | no | `Markdown` or `HTML` for caption formatting |
+
+**Output:** Same `Message` object as `send_message`, with the photo metadata included.
+
+## Available triggers
+
+| Trigger ID | Name | Type | Description |
+|---|---|---|---|
+| `new_message` | New Message | Webhook | Fires when the bot receives any message |
+
+### `new_message` — New Message
+
+This is a **webhook trigger** — Telegram pushes events to your FluxTurn instance, so the bot must be reachable from the public internet (use a tunnel like ngrok in dev). FluxTurn registers the webhook automatically when the workflow is activated.
+
+**Output payload:**
+
+| Field | Type | Description |
+|---|---|---|
+| `message_id` | number | Telegram's unique message ID |
+| `text` | string | The message body |
+| `from` | object | Sender info (`id`, `username`, `first_name`, etc.) |
+| `chat` | object | Chat info (`id`, `type`, `title`) |
+
+## Common gotchas
+
+- **Bots can't initiate conversations.** Your bot can only message a user/group/channel that has *already* interacted with it (sent a message, added it to a group, etc.). New users have to send `/start` to your bot first before you can message them.
+- **Group privacy mode.** By default, bots in groups only see messages that mention them or use commands. To receive every message in a group, disable privacy mode in BotFather: `/setprivacy` → select your bot → Disable.
+- **Channels need admin access.** To post in a channel, your bot must be added as an administrator with the "Post Messages" permission.
+- **Webhook needs HTTPS in production.** Telegram only delivers webhooks to HTTPS URLs with valid certificates. For local development, use a tunnel (ngrok, cloudflared) and FluxTurn will register the public URL.
+- **Rate limits.** Telegram allows ~30 messages/second to different chats and ~1 message/second to the same chat. Burst sends to many users can hit limits — use the **Wait** node between messages if you're broadcasting.
+- **`parseMode` errors.** If you set `parseMode: 'Markdown'` and the message contains unescaped special characters (`_`, `*`, `[`, `` ` ``), the API rejects the message. Either escape them or use plain text.
+
+## Example workflow
+
+**Goal:** Send a Telegram alert to a private channel whenever a new GitHub issue is opened on a watched repository.
+
+**Nodes:**
+
+1. **GitHub - New Issue** (GitHub trigger)
+   - Repository: `your-org/your-repo`
+2. **Telegram - Send Message** (Telegram action)
+   - Chat ID: `-1001234567890` (your private channel)
+   - Parse Mode: `Markdown`
+   - Text:
+     ```
+     *New issue:* {{$json.issue.title}}
+     *By:* {{$json.issue.user.login}}
+     {{$json.issue.html_url}}
+     ```
+
+When activated, every issue opened on the watched repo posts a formatted alert to the Telegram channel.
+
+## Links
+
+- [Telegram Bot API documentation](https://core.telegram.org/bots/api)
+- [BotFather guide](https://core.telegram.org/bots#botfather)
+- [FluxTurn connector source](../../backend/src/modules/fluxturn/connectors/communication/telegram/telegram.connector.ts)

--- a/frontend/src/pages/Docs.tsx
+++ b/frontend/src/pages/Docs.tsx
@@ -642,6 +642,55 @@ const docsContent: Record<string, { title: string; content: React.ReactNode }> =
           <li><strong>Webhooks:</strong> Real-time event notifications</li>
         </ul>
 
+        <h3 className="text-2xl font-bold text-gray-900 mt-8 mb-4">Per-Connector Setup Guides</h3>
+        <p className="text-gray-700 mb-4">
+          Detailed setup instructions, action/trigger references, and example workflows for each connector live
+          in markdown files in the repository, where they're easy to read on GitHub and easy to contribute to.
+        </p>
+        <div className="bg-gray-50 rounded-lg p-4 mb-4">
+          <p className="text-gray-700 mb-2">
+            Browse all connector docs:
+          </p>
+          <a
+            href="https://github.com/fluxturn/fluxturn/tree/main/docs/connectors"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-cyan-600 hover:underline font-mono text-sm break-all"
+          >
+            github.com/fluxturn/fluxturn/tree/main/docs/connectors
+          </a>
+        </div>
+        <p className="text-gray-700 mb-4">
+          Reference docs (use these as the gold standard for new contributions):
+        </p>
+        <ul className="list-disc list-inside space-y-2 text-gray-700 mb-4">
+          <li>
+            <a href="https://github.com/fluxturn/fluxturn/blob/main/docs/connectors/telegram.md" target="_blank" rel="noopener noreferrer" className="text-cyan-600 hover:underline">
+              Telegram
+            </a>{" "}
+            — simple API key auth
+          </li>
+          <li>
+            <a href="https://github.com/fluxturn/fluxturn/blob/main/docs/connectors/gmail.md" target="_blank" rel="noopener noreferrer" className="text-cyan-600 hover:underline">
+              Gmail
+            </a>{" "}
+            — OAuth2 with polling triggers
+          </li>
+          <li>
+            <a href="https://github.com/fluxturn/fluxturn/blob/main/docs/connectors/slack.md" target="_blank" rel="noopener noreferrer" className="text-cyan-600 hover:underline">
+              Slack
+            </a>{" "}
+            — Bearer token with webhook (Events API) triggers
+          </li>
+        </ul>
+        <p className="text-gray-700">
+          Want to help document a connector? See the{" "}
+          <a href="https://github.com/fluxturn/fluxturn/blob/main/CONTRIBUTING.md#documenting-a-connector" target="_blank" rel="noopener noreferrer" className="text-cyan-600 hover:underline">
+            Documenting a Connector
+          </a>{" "}
+          section in CONTRIBUTING.md.
+        </p>
+
         <div className="bg-cyan-50 border-l-4 border-cyan-500 p-4 mt-6 rounded-r-lg">
           <p className="text-cyan-800">
             Can't find your service? Use the <Link to="/docs/http-request" className="underline">HTTP Request</Link> node to connect to any REST API.


### PR DESCRIPTION
…docs

Sets up the structure for crowdsourced per-connector documentation. Each of the 126 connectors will eventually get its own markdown file in docs/connectors/, contributed via PR by community members who use that service. This commit lays the foundation: a template, three reference docs to set the bar, an index, the contribution guide, and a draft tracking issue.

New files in docs/connectors/:

- _template.md The skeleton contributors copy. Sections: header (category, auth type, webhook support, source path), Overview, Setup, Available actions, Available triggers, Common gotchas, Example workflow, Links. Inline `> ` notes guide contributors through filling it in.

- telegram.md (reference: simple API key auth) Two actions (send_message, send_photo), one webhook trigger (new_message), bot setup via BotFather, common gotchas around bots-can't-initiate, group privacy mode, channel admin perms, HTTPS webhook requirement, rate limits, parseMode escaping. Includes a real example workflow (GitHub issue → Telegram alert).

- gmail.md (reference: OAuth2 + polling triggers) Seven actions (send_email, get_emails, create_draft, add_label, search_emails, delete_email, mark_as_read) and two polling triggers (email_received, email_sent). Setup walks through Google Cloud OAuth client creation, scope requirements, the FluxTurn GOOGLE_OAUTH_* env vars, and the in-app OAuth flow. Gotchas cover sticky scopes, polling delay, sending limits, attachment size, search query escaping, and labelIds vs label names. Example workflow: invoice email → Drive upload → Slack notify.

- slack.md (reference: Bearer token + webhook (Events API) triggers) 17 actions (send_message, update_message, channels, files, users, search, etc.) and 7 webhook triggers (message, app_mention, reaction_added, etc.). Setup covers Slack app creation, the full list of bot token scopes, install flow, and Events API URL config. Gotchas cover bot-must-be-in-channel, channel ID vs name, threading, Block Kit vs text fallback, rate limit tiers, HTTPS Events API requirement, the URL verification timing trick, and sticky scopes after reinstall. Example workflow: @bot mention → OpenAI classify → threaded Slack reply.

- README.md (the index) Lists all 126 connectors organized into 21 categories with checkbox status. The 3 documented connectors are checked; the rest link to their source paths so contributors can find them. Includes a "Contributing" section pointing at the template and CONTRIBUTING.md. Notes the Jotform/YouTube duplicates and the internal `implementations/redis.connector.ts` exclusion.

- _TRACKING_ISSUE_DRAFT.md The body for the GitHub umbrella tracking issue. Contributors claim a connector by commenting, the maintainer assigns. Has the full 126-checkbox list, contribution instructions, and an HTML comment at the top with usage notes. Delete the file once the issue is created on GitHub.

Existing files updated:

- CONTRIBUTING.md Added a "Documenting a Connector" section after "Adding a New Connector". 7-step workflow (claim → read template → read source → copy template → fill in → PR → update tracker), plus tips on staying accurate to source and using placeholder URLs.

- frontend/src/pages/Docs.tsx Added a "Per-Connector Setup Guides" section to the in-app Integrations Overview page (/docs/integrations-overview), linking out to the docs/connectors directory on GitHub plus the three reference docs. App users browsing /docs now have a clear path to detailed connector docs.

Verified before writing: each reference doc was built by reading the connector's actual TypeScript source (telegram.connector.ts, gmail.connector.ts, slack.connector.ts) and using the real getActions() / getTriggers() output. No invented features.

Next step (not in this commit): the user opens the umbrella tracking issue on GitHub using _TRACKING_ISSUE_DRAFT.md as the body, labels it documentation/good first issue/help wanted, then deletes the draft file.

