### PR TITLE
feat(alerting): configurable failure alerting system

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { EventsModule } from './events/events.module';
 import { QdrantModule } from './modules/qdrant/qdrant.module';
 import { DatabaseBrowserModule } from './modules/database-browser/database-browser.module';
 import { BlogModule } from './modules/blog/blog.module';
+import { AlertingModule } from './modules/alerting/alerting.module';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { BlogModule } from './modules/blog/blog.module';
     EventsModule,
     DatabaseBrowserModule,
     BlogModule,
+    AlertingModule,
   ],
   controllers: [HealthController],
   providers: [],

--- a/backend/src/database/migrations/002_alert_configurations.sql
+++ b/backend/src/database/migrations/002_alert_configurations.sql
@@ -1,0 +1,20 @@
+-- Migration: Create alert_configurations table for workflow failure alerting
+-- Related to: GitHub issue #124
+
+CREATE TABLE IF NOT EXISTS alert_configurations (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  organization_id UUID NOT NULL,
+  channel VARCHAR(20) NOT NULL CHECK (channel IN ('email', 'webhook', 'slack')),
+  config JSONB NOT NULL DEFAULT '{}',
+  conditions JSONB NOT NULL DEFAULT '{"onEveryFailure": true}',
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_alert_configurations_org_id
+  ON alert_configurations (organization_id);
+
+CREATE INDEX IF NOT EXISTS idx_alert_configurations_org_active
+  ON alert_configurations (organization_id, is_active)
+  WHERE is_active = true;

--- a/backend/src/modules/alerting/alerting.controller.ts
+++ b/backend/src/modules/alerting/alerting.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Put,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Request,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiSecurity, ApiHeader } from '@nestjs/swagger';
+import { JwtOrApiKeyAuthGuard } from '../auth/guards/jwt-or-api-key-auth.guard';
+import { AlertingService } from './alerting.service';
+import { CreateAlertConfigDto, UpdateAlertConfigDto } from './dto/alert-config.dto';
+
+@ApiTags('alerts')
+@Controller('alerts')
+@UseGuards(JwtOrApiKeyAuthGuard)
+@ApiSecurity('api_key')
+@ApiSecurity('JWT')
+@ApiHeader({
+  name: 'x-organization-id',
+  description: 'Organization ID for multi-tenant context',
+  required: false,
+})
+export class AlertingController {
+  constructor(private readonly alertingService: AlertingService) {}
+
+  @Post('config')
+  @ApiOperation({ summary: 'Configure alert channels for the organization' })
+  @ApiResponse({ status: 201, description: 'Alert configuration created' })
+  async createAlertConfig(
+    @Body(ValidationPipe) dto: CreateAlertConfigDto,
+    @Request() req: any,
+  ) {
+    const orgId = req.headers['x-organization-id'] || req.auth?.organizationId;
+    return this.alertingService.configureAlerts(orgId, dto);
+  }
+
+  @Get('config')
+  @ApiOperation({ summary: 'Get all alert configurations for the organization' })
+  @ApiResponse({ status: 200, description: 'List of alert configurations' })
+  async getAlertConfigs(@Request() req: any) {
+    const orgId = req.headers['x-organization-id'] || req.auth?.organizationId;
+    return this.alertingService.getAlertConfigs(orgId);
+  }
+
+  @Put('config/:id')
+  @ApiOperation({ summary: 'Update an alert configuration' })
+  @ApiResponse({ status: 200, description: 'Alert configuration updated' })
+  async updateAlertConfig(
+    @Param('id') id: string,
+    @Body(ValidationPipe) dto: UpdateAlertConfigDto,
+    @Request() req: any,
+  ) {
+    const orgId = req.headers['x-organization-id'] || req.auth?.organizationId;
+    return this.alertingService.updateAlertConfig(id, orgId, dto);
+  }
+
+  @Delete('config/:id')
+  @ApiOperation({ summary: 'Delete an alert configuration' })
+  @ApiResponse({ status: 200, description: 'Alert configuration deleted' })
+  async deleteAlertConfig(@Param('id') id: string, @Request() req: any) {
+    const orgId = req.headers['x-organization-id'] || req.auth?.organizationId;
+    await this.alertingService.deleteAlertConfig(id, orgId);
+    return { message: 'Alert configuration deleted' };
+  }
+}

--- a/backend/src/modules/alerting/alerting.module.ts
+++ b/backend/src/modules/alerting/alerting.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { AlertingController } from './alerting.controller';
+import { AlertingService } from './alerting.service';
+import { EmailModule } from '../email/email.module';
+import { DatabaseModule } from '../database/database.module';
+
+@Module({
+  imports: [ConfigModule, DatabaseModule, EmailModule],
+  controllers: [AlertingController],
+  providers: [AlertingService],
+  exports: [AlertingService],
+})
+export class AlertingModule {}

--- a/backend/src/modules/alerting/alerting.service.ts
+++ b/backend/src/modules/alerting/alerting.service.ts
@@ -1,0 +1,388 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PlatformService } from '../database/platform.service';
+import { EmailService } from '../email/email.service';
+import {
+  CreateAlertConfigDto,
+  UpdateAlertConfigDto,
+  AlertChannel,
+} from './dto/alert-config.dto';
+import { v4 as uuidv4 } from 'uuid';
+import * as crypto from 'crypto';
+import axios from 'axios';
+
+@Injectable()
+export class AlertingService {
+  private readonly logger = new Logger(AlertingService.name);
+
+  constructor(
+    private readonly platformService: PlatformService,
+    private readonly emailService: EmailService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * Create the alert_configurations table if it does not exist
+   */
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.platformService.query(`
+        CREATE TABLE IF NOT EXISTS alert_configurations (
+          id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+          organization_id UUID NOT NULL,
+          channel VARCHAR(20) NOT NULL CHECK (channel IN ('email', 'webhook', 'slack')),
+          config JSONB NOT NULL DEFAULT '{}',
+          conditions JSONB NOT NULL DEFAULT '{"onEveryFailure": true}',
+          is_active BOOLEAN NOT NULL DEFAULT true,
+          created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+          updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+        )
+      `);
+      this.logger.log('alert_configurations table ensured');
+    } catch (error) {
+      this.logger.error('Failed to create alert_configurations table', error);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // CRUD
+  // ---------------------------------------------------------------------------
+
+  async configureAlerts(
+    orgId: string,
+    dto: CreateAlertConfigDto,
+  ): Promise<any> {
+    const id = uuidv4();
+    const result = await this.platformService.query(
+      `INSERT INTO alert_configurations
+        (id, organization_id, channel, config, conditions, is_active, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
+       RETURNING *`,
+      [
+        id,
+        orgId,
+        dto.channel,
+        JSON.stringify(dto.config),
+        JSON.stringify(dto.conditions || { onEveryFailure: true }),
+        dto.is_active !== false,
+      ],
+    );
+    return result.rows[0];
+  }
+
+  async getAlertConfigs(orgId: string): Promise<any[]> {
+    const result = await this.platformService.query(
+      `SELECT * FROM alert_configurations
+       WHERE organization_id = $1
+       ORDER BY created_at DESC`,
+      [orgId],
+    );
+    return result.rows;
+  }
+
+  async getAlertConfigById(id: string, orgId: string): Promise<any> {
+    const result = await this.platformService.query(
+      `SELECT * FROM alert_configurations WHERE id = $1 AND organization_id = $2`,
+      [id, orgId],
+    );
+    if (result.rows.length === 0) {
+      throw new NotFoundException('Alert configuration not found');
+    }
+    return result.rows[0];
+  }
+
+  async updateAlertConfig(
+    id: string,
+    orgId: string,
+    dto: UpdateAlertConfigDto,
+  ): Promise<any> {
+    // Verify existence
+    await this.getAlertConfigById(id, orgId);
+
+    const sets: string[] = [];
+    const values: any[] = [];
+    let paramIdx = 1;
+
+    if (dto.channel !== undefined) {
+      sets.push(`channel = $${paramIdx++}`);
+      values.push(dto.channel);
+    }
+    if (dto.config !== undefined) {
+      sets.push(`config = $${paramIdx++}`);
+      values.push(JSON.stringify(dto.config));
+    }
+    if (dto.conditions !== undefined) {
+      sets.push(`conditions = $${paramIdx++}`);
+      values.push(JSON.stringify(dto.conditions));
+    }
+    if (dto.is_active !== undefined) {
+      sets.push(`is_active = $${paramIdx++}`);
+      values.push(dto.is_active);
+    }
+
+    sets.push(`updated_at = NOW()`);
+
+    values.push(id);
+    values.push(orgId);
+
+    const result = await this.platformService.query(
+      `UPDATE alert_configurations
+       SET ${sets.join(', ')}
+       WHERE id = $${paramIdx++} AND organization_id = $${paramIdx}
+       RETURNING *`,
+      values,
+    );
+    return result.rows[0];
+  }
+
+  async deleteAlertConfig(id: string, orgId: string): Promise<void> {
+    await this.getAlertConfigById(id, orgId);
+    await this.platformService.query(
+      `DELETE FROM alert_configurations WHERE id = $1 AND organization_id = $2`,
+      [id, orgId],
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Alert dispatch
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Called when a workflow execution fails.
+   * Looks up alert configs for the workflow's organization and dispatches
+   * alerts to every active, matching channel.
+   */
+  async sendAlert(
+    workflowId: string,
+    executionId: string,
+    error: { message: string; stack?: string },
+    meta?: {
+      workflowName?: string;
+      organizationId?: string;
+      failedNodeId?: string;
+      failedNodeName?: string;
+    },
+  ): Promise<void> {
+    const orgId = meta?.organizationId;
+    if (!orgId) {
+      this.logger.warn('sendAlert called without organizationId; skipping');
+      return;
+    }
+
+    try {
+      const configs = await this.getAlertConfigs(orgId);
+      const activeConfigs = configs.filter((c) => c.is_active);
+
+      if (activeConfigs.length === 0) {
+        return;
+      }
+
+      for (const cfg of activeConfigs) {
+        try {
+          const shouldAlert = await this.evaluateConditions(
+            cfg.conditions,
+            workflowId,
+            orgId,
+          );
+          if (!shouldAlert) continue;
+
+          switch (cfg.channel as AlertChannel) {
+            case AlertChannel.EMAIL:
+              await this.sendEmailAlert(cfg.config, workflowId, executionId, error, meta);
+              break;
+            case AlertChannel.WEBHOOK:
+              await this.sendWebhookAlert(cfg.config, workflowId, executionId, error, meta);
+              break;
+            case AlertChannel.SLACK:
+              await this.sendSlackAlert(cfg.config, workflowId, executionId, error, meta);
+              break;
+          }
+        } catch (channelError) {
+          this.logger.error(
+            `Failed to send alert via ${cfg.channel} (config ${cfg.id}): ${channelError.message}`,
+          );
+        }
+      }
+    } catch (err) {
+      this.logger.error(`sendAlert failed: ${err.message}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Condition evaluation
+  // ---------------------------------------------------------------------------
+
+  private async evaluateConditions(
+    conditions: any,
+    workflowId: string,
+    orgId: string,
+  ): Promise<boolean> {
+    if (!conditions) return true;
+
+    // Default: alert on every failure
+    if (conditions.onEveryFailure !== false) return true;
+
+    // Error-rate threshold
+    if (conditions.errorRateThreshold != null) {
+      const windowMinutes = conditions.errorRateWindowMinutes || 60;
+      const result = await this.platformService.query(
+        `SELECT
+           COUNT(*) FILTER (WHERE status = 'failed') AS failed,
+           COUNT(*) AS total
+         FROM workflow_executions
+         WHERE workflow_id = $1
+           AND organization_id = $2
+           AND created_at >= NOW() - INTERVAL '1 minute' * $3`,
+        [workflowId, orgId, windowMinutes],
+      );
+      const row = result.rows[0];
+      const total = parseInt(row.total, 10);
+      if (total === 0) return true;
+      const rate = parseInt(row.failed, 10) / total;
+      return rate >= conditions.errorRateThreshold;
+    }
+
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Channel implementations
+  // ---------------------------------------------------------------------------
+
+  private async sendEmailAlert(
+    config: any,
+    workflowId: string,
+    executionId: string,
+    error: { message: string; stack?: string },
+    meta?: any,
+  ): Promise<void> {
+    if (!config?.email) {
+      this.logger.warn('Email alert config missing email address');
+      return;
+    }
+
+    const appUrl = this.configService.get<string>('APP_URL', 'http://localhost:3000');
+    const detailsLink = `${appUrl}/workflows/${workflowId}/executions/${executionId}`;
+
+    await this.emailService.sendEmail({
+      to: config.email,
+      subject: `[FluxTurn] Workflow execution failed: ${meta?.workflowName || workflowId}`,
+      html: `
+        <h2>Workflow Execution Failed</h2>
+        <table style="border-collapse:collapse;">
+          <tr><td style="padding:4px 12px;font-weight:bold;">Workflow</td><td style="padding:4px 12px;">${meta?.workflowName || workflowId}</td></tr>
+          <tr><td style="padding:4px 12px;font-weight:bold;">Execution ID</td><td style="padding:4px 12px;">${executionId}</td></tr>
+          <tr><td style="padding:4px 12px;font-weight:bold;">Failed Node</td><td style="padding:4px 12px;">${meta?.failedNodeName || 'N/A'}</td></tr>
+          <tr><td style="padding:4px 12px;font-weight:bold;">Error</td><td style="padding:4px 12px;">${error.message}</td></tr>
+          <tr><td style="padding:4px 12px;font-weight:bold;">Timestamp</td><td style="padding:4px 12px;">${new Date().toISOString()}</td></tr>
+        </table>
+        <p><a href="${detailsLink}">View Execution Details</a></p>
+      `,
+      text: `Workflow "${meta?.workflowName || workflowId}" failed.\nExecution: ${executionId}\nError: ${error.message}\nDetails: ${detailsLink}`,
+      skipLogging: true,
+    });
+
+    this.logger.log(`Email alert sent to ${config.email} for execution ${executionId}`);
+  }
+
+  private async sendWebhookAlert(
+    config: any,
+    workflowId: string,
+    executionId: string,
+    error: { message: string; stack?: string },
+    meta?: any,
+  ): Promise<void> {
+    if (!config?.url) {
+      this.logger.warn('Webhook alert config missing URL');
+      return;
+    }
+
+    const payload = {
+      event: 'workflow.execution.failed',
+      workflow_id: workflowId,
+      workflow_name: meta?.workflowName || null,
+      execution_id: executionId,
+      failed_node_id: meta?.failedNodeId || null,
+      failed_node_name: meta?.failedNodeName || null,
+      error: {
+        message: error.message,
+        stack: error.stack || null,
+      },
+      timestamp: new Date().toISOString(),
+    };
+
+    const body = JSON.stringify(payload);
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (config.webhookSecret) {
+      const signature = crypto
+        .createHmac('sha256', config.webhookSecret)
+        .update(body)
+        .digest('hex');
+      headers['X-FluxTurn-Signature'] = `sha256=${signature}`;
+    }
+
+    await axios.post(config.url, body, { headers, timeout: 10000 });
+    this.logger.log(`Webhook alert sent to ${config.url} for execution ${executionId}`);
+  }
+
+  private async sendSlackAlert(
+    config: any,
+    workflowId: string,
+    executionId: string,
+    error: { message: string; stack?: string },
+    meta?: any,
+  ): Promise<void> {
+    if (!config?.slackWebhookUrl) {
+      this.logger.warn('Slack alert config missing slackWebhookUrl');
+      return;
+    }
+
+    const appUrl = this.configService.get<string>('APP_URL', 'http://localhost:3000');
+    const detailsLink = `${appUrl}/workflows/${workflowId}/executions/${executionId}`;
+
+    const slackPayload = {
+      blocks: [
+        {
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text: 'Workflow Execution Failed',
+            emoji: true,
+          },
+        },
+        {
+          type: 'section',
+          fields: [
+            { type: 'mrkdwn', text: `*Workflow:*\n${meta?.workflowName || workflowId}` },
+            { type: 'mrkdwn', text: `*Execution:*\n\`${executionId}\`` },
+            { type: 'mrkdwn', text: `*Failed Node:*\n${meta?.failedNodeName || 'N/A'}` },
+            { type: 'mrkdwn', text: `*Time:*\n${new Date().toISOString()}` },
+          ],
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*Error:*\n\`\`\`${error.message}\`\`\``,
+          },
+        },
+        {
+          type: 'actions',
+          elements: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: 'View Details' },
+              url: detailsLink,
+            },
+          ],
+        },
+      ],
+    };
+
+    await axios.post(config.slackWebhookUrl, slackPayload, { timeout: 10000 });
+    this.logger.log(`Slack alert sent for execution ${executionId}`);
+  }
+}

--- a/backend/src/modules/alerting/dto/alert-config.dto.ts
+++ b/backend/src/modules/alerting/dto/alert-config.dto.ts
@@ -1,0 +1,111 @@
+import {
+  IsString,
+  IsEnum,
+  IsObject,
+  IsOptional,
+  IsBoolean,
+  ValidateNested,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export enum AlertChannel {
+  EMAIL = 'email',
+  WEBHOOK = 'webhook',
+  SLACK = 'slack',
+}
+
+export class AlertChannelConfigDto {
+  @ApiPropertyOptional({ description: 'Email address for email channel' })
+  @IsOptional()
+  @IsString()
+  email?: string;
+
+  @ApiPropertyOptional({ description: 'URL for webhook channel' })
+  @IsOptional()
+  @IsString()
+  url?: string;
+
+  @ApiPropertyOptional({ description: 'HMAC secret for webhook signature verification' })
+  @IsOptional()
+  @IsString()
+  webhookSecret?: string;
+
+  @ApiPropertyOptional({ description: 'Slack incoming webhook URL' })
+  @IsOptional()
+  @IsString()
+  slackWebhookUrl?: string;
+}
+
+export class AlertConditionsDto {
+  @ApiPropertyOptional({
+    description: 'Alert on every failure',
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  onEveryFailure?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Alert only when error rate exceeds this threshold (0-1)',
+  })
+  @IsOptional()
+  errorRateThreshold?: number;
+
+  @ApiPropertyOptional({
+    description: 'Time window in minutes for error rate calculation',
+    default: 60,
+  })
+  @IsOptional()
+  errorRateWindowMinutes?: number;
+}
+
+export class CreateAlertConfigDto {
+  @ApiProperty({ enum: AlertChannel, description: 'Alert channel type' })
+  @IsEnum(AlertChannel)
+  channel: AlertChannel;
+
+  @ApiProperty({ description: 'Channel-specific configuration' })
+  @IsObject()
+  @ValidateNested()
+  @Type(() => AlertChannelConfigDto)
+  config: AlertChannelConfigDto;
+
+  @ApiPropertyOptional({ description: 'Alert conditions' })
+  @IsOptional()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => AlertConditionsDto)
+  conditions?: AlertConditionsDto;
+
+  @ApiPropertyOptional({ description: 'Whether the alert config is active', default: true })
+  @IsOptional()
+  @IsBoolean()
+  is_active?: boolean;
+}
+
+export class UpdateAlertConfigDto {
+  @ApiPropertyOptional({ enum: AlertChannel, description: 'Alert channel type' })
+  @IsOptional()
+  @IsEnum(AlertChannel)
+  channel?: AlertChannel;
+
+  @ApiPropertyOptional({ description: 'Channel-specific configuration' })
+  @IsOptional()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => AlertChannelConfigDto)
+  config?: AlertChannelConfigDto;
+
+  @ApiPropertyOptional({ description: 'Alert conditions' })
+  @IsOptional()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => AlertConditionsDto)
+  conditions?: AlertConditionsDto;
+
+  @ApiPropertyOptional({ description: 'Whether the alert config is active' })
+  @IsOptional()
+  @IsBoolean()
+  is_active?: boolean;
+}

--- a/backend/src/modules/fluxturn/workflow/workflow.module.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.module.ts
@@ -80,6 +80,7 @@ import { AvailableNodesSeederService } from './services/available-nodes-seeder.s
 import { NodesModule } from './nodes/nodes.module';
 import { WorkflowAgentsService } from './services/workflow-agents.service';
 import { OrchestratedGeneratorService } from './services/orchestrated-generator.service';
+import { AlertingModule } from '../../alerting/alerting.module';
 // import { TemplateSeederService } from './services/template-seeder.service';
 
 @Module({
@@ -92,6 +93,7 @@ import { OrchestratedGeneratorService } from './services/orchestrated-generator.
     forwardRef(() => ConnectorsModule),
     EventsModule,
     NodesModule,
+    AlertingModule,
   ],
   controllers: [
     TemplateController, // Must be before WorkflowController to avoid route conflicts

--- a/backend/src/modules/fluxturn/workflow/workflow.service.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.service.ts
@@ -11,6 +11,7 @@ import { TriggerManagerService } from './services/trigger-manager.service';
 import { TriggerType } from './interfaces/trigger.interface';
 import { AIWorkflowGeneratorService } from './services/ai-workflow-generator.service';
 import { IntentDetectionService } from './services/intent-detection.service';
+import { AlertingService } from '../../alerting/alerting.service';
 // compareConnectorFields removed - seeding now done via npm run seed:connector
 
 @Injectable()
@@ -28,6 +29,8 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
     private triggerManager: TriggerManagerService,
     private aiWorkflowGenerator: AIWorkflowGeneratorService,
     private intentDetection: IntentDetectionService,
+    @Inject(forwardRef(() => AlertingService))
+    private alertingService: AlertingService,
   ) {}
 
   async onModuleInit() {
@@ -475,6 +478,23 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
           JSON.stringify(outputDataWithoutBinary),
           executionId
         ]);
+
+        // Send failure alerts (fire-and-forget; should not block response)
+        this.alertingService
+          .sendAlert(
+            params.workflow_id,
+            executionId,
+            { message: executionError.message, stack: executionError.stack },
+            {
+              workflowName: workflowRow.name,
+              organizationId: workflowRow.organization_id,
+              failedNodeId: outputData?.failedNodeId,
+              failedNodeName: outputData?.failedNodeName,
+            },
+          )
+          .catch((alertErr) =>
+            this.logger.error(`Alert dispatch error: ${alertErr.message}`),
+          );
 
         // Return the failed execution with detailed error info
         // This allows frontend to see per-node status


### PR DESCRIPTION
## Summary
- Adds an `AlertingModule` with service, controller, DTOs, and migration for the `alert_configurations` table
- Supports three alert channels: **email** (via existing SES infrastructure), **webhook** (POST with HMAC signature), and **Slack** (incoming webhook with Block Kit message)
- Alert conditions: fire on every failure, or only when error rate exceeds a configurable threshold within a time window
- Integrates into `WorkflowService.executeWorkflow()` -- alerts are dispatched fire-and-forget after a failed execution is persisted to the database

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | `/alerts/config` | Create alert config |
| GET | `/alerts/config` | List alert configs |
| PUT | `/alerts/config/:id` | Update alert config |
| DELETE | `/alerts/config/:id` | Delete alert config |

## Test plan
- [ ] Create email, webhook, and Slack alert configurations via API
- [ ] Trigger a workflow failure and verify alerts are dispatched to each channel
- [ ] Verify error-rate threshold conditions suppress alerts below threshold
- [ ] Verify `npx tsc --noEmit` passes with 0 errors

Closes #124

Generated with [Claude Code](https://claude.com/claude-code)