### PR TITLE
feat: audit log API with filtering and pagination

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { EventsModule } from './events/events.module';
 import { QdrantModule } from './modules/qdrant/qdrant.module';
 import { DatabaseBrowserModule } from './modules/database-browser/database-browser.module';
 import { BlogModule } from './modules/blog/blog.module';
+import { AuditModule } from './modules/fluxturn/audit/audit.module';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { BlogModule } from './modules/blog/blog.module';
     EventsModule,
     DatabaseBrowserModule,
     BlogModule,
+    AuditModule,
   ],
   controllers: [HealthController],
   providers: [],

--- a/backend/src/modules/fluxturn/audit/audit.controller.ts
+++ b/backend/src/modules/fluxturn/audit/audit.controller.ts
@@ -1,0 +1,108 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiSecurity, ApiQuery } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { AuditService, AuditLogFilters, PaginationOptions } from './audit.service';
+
+@ApiTags('Audit Logs')
+@Controller('audit-logs')
+@UseGuards(JwtAuthGuard)
+@ApiSecurity('JWT')
+export class AuditController {
+  constructor(private readonly auditService: AuditService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List audit logs with filtering and pagination' })
+  @ApiQuery({ name: 'action', required: false })
+  @ApiQuery({ name: 'userId', required: false })
+  @ApiQuery({ name: 'resourceType', required: false })
+  @ApiQuery({ name: 'dateFrom', required: false })
+  @ApiQuery({ name: 'dateTo', required: false })
+  @ApiQuery({ name: 'search', required: false })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'sortBy', required: false })
+  @ApiQuery({ name: 'sortOrder', required: false, enum: ['ASC', 'DESC'] })
+  async list(
+    @Request() req: any,
+    @Query('action') action?: string,
+    @Query('userId') userId?: string,
+    @Query('resourceType') resourceType?: string,
+    @Query('dateFrom') dateFrom?: string,
+    @Query('dateTo') dateTo?: string,
+    @Query('search') search?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('sortBy') sortBy?: string,
+    @Query('sortOrder') sortOrder?: string,
+  ) {
+    const orgId = this.extractOrgId(req);
+
+    const filters: AuditLogFilters = {
+      action,
+      userId,
+      resourceType,
+      dateFrom,
+      dateTo,
+      search,
+    };
+
+    const pagination: PaginationOptions = {
+      page: page ? parseInt(page, 10) : 1,
+      limit: limit ? Math.min(parseInt(limit, 10), 100) : 25,
+      sortBy: sortBy || 'created_at',
+      sortOrder: (sortOrder === 'ASC' ? 'ASC' : 'DESC') as 'ASC' | 'DESC',
+    };
+
+    return this.auditService.query(orgId, filters, pagination);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single audit log entry' })
+  async getById(@Param('id') id: string, @Request() req: any) {
+    const orgId = this.extractOrgId(req);
+    const entry = await this.auditService.getById(id, orgId);
+
+    if (!entry) {
+      throw new NotFoundException('Audit log entry not found');
+    }
+
+    return entry;
+  }
+
+  @Get('resource/:type/:id')
+  @ApiOperation({ summary: 'Get audit logs for a specific resource' })
+  async getByResource(
+    @Param('type') resourceType: string,
+    @Param('id') resourceId: string,
+    @Request() req: any,
+  ) {
+    const orgId = this.extractOrgId(req);
+    return this.auditService.getByResource(resourceType, resourceId, orgId);
+  }
+
+  /**
+   * Extract organization ID from request headers or user context.
+   */
+  private extractOrgId(req: any): string {
+    const orgId =
+      req.headers?.['x-organization-id'] ||
+      req.user?.organizationId;
+
+    if (!orgId) {
+      throw new BadRequestException(
+        'Organization ID is required. Pass it via the x-organization-id header.',
+      );
+    }
+
+    return orgId;
+  }
+}

--- a/backend/src/modules/fluxturn/audit/audit.module.ts
+++ b/backend/src/modules/fluxturn/audit/audit.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuditController } from './audit.controller';
+import { AuditService } from './audit.service';
+
+@Module({
+  controllers: [AuditController],
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/backend/src/modules/fluxturn/audit/audit.service.ts
+++ b/backend/src/modules/fluxturn/audit/audit.service.ts
@@ -1,0 +1,214 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PlatformService } from '../../database/platform.service';
+import { AuditLog } from '../../database/interfaces/platform.interface';
+
+export type AuditAction =
+  | 'workflow.created'
+  | 'workflow.updated'
+  | 'workflow.deleted'
+  | 'workflow.executed'
+  | 'credential.created'
+  | 'credential.updated'
+  | 'member.invited'
+  | 'member.removed'
+  | 'settings.changed';
+
+export interface AuditLogFilters {
+  action?: string;
+  userId?: string;
+  resourceType?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  search?: string;
+}
+
+export interface PaginationOptions {
+  page?: number;
+  limit?: number;
+  sortBy?: string;
+  sortOrder?: 'ASC' | 'DESC';
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+@Injectable()
+export class AuditService {
+  private readonly logger = new Logger(AuditService.name);
+
+  constructor(private readonly platformService: PlatformService) {}
+
+  /**
+   * Write an audit log entry.
+   */
+  async log(
+    action: AuditAction | string,
+    userId: string,
+    resourceType: string,
+    resourceId?: string,
+    metadata?: {
+      organizationId?: string;
+      projectId?: string;
+      details?: Record<string, any>;
+      ipAddress?: string;
+      userAgent?: string;
+    },
+  ): Promise<AuditLog> {
+    return this.platformService.createAuditLog({
+      userId,
+      organizationId: metadata?.organizationId,
+      projectId: metadata?.projectId,
+      action,
+      resourceType,
+      resourceId,
+      details: metadata?.details || {},
+      ipAddress: metadata?.ipAddress,
+      userAgent: metadata?.userAgent,
+    });
+  }
+
+  /**
+   * Query audit logs with filtering and pagination.
+   */
+  async query(
+    orgId: string,
+    filters: AuditLogFilters = {},
+    pagination: PaginationOptions = {},
+  ): Promise<PaginatedResult<AuditLog>> {
+    const {
+      page = 1,
+      limit = 25,
+      sortBy = 'created_at',
+      sortOrder = 'DESC',
+    } = pagination;
+
+    const offset = (page - 1) * limit;
+
+    // Build WHERE clause
+    const conditions: string[] = ['organization_id = $1'];
+    const params: any[] = [orgId];
+    let paramIndex = 2;
+
+    if (filters.action) {
+      conditions.push(`action = $${paramIndex}`);
+      params.push(filters.action);
+      paramIndex++;
+    }
+
+    if (filters.userId) {
+      conditions.push(`user_id = $${paramIndex}`);
+      params.push(filters.userId);
+      paramIndex++;
+    }
+
+    if (filters.resourceType) {
+      conditions.push(`resource_type = $${paramIndex}`);
+      params.push(filters.resourceType);
+      paramIndex++;
+    }
+
+    if (filters.dateFrom) {
+      conditions.push(`created_at >= $${paramIndex}`);
+      params.push(filters.dateFrom);
+      paramIndex++;
+    }
+
+    if (filters.dateTo) {
+      conditions.push(`created_at <= $${paramIndex}`);
+      params.push(filters.dateTo);
+      paramIndex++;
+    }
+
+    if (filters.search) {
+      conditions.push(`(action ILIKE $${paramIndex} OR resource_type ILIKE $${paramIndex} OR details::text ILIKE $${paramIndex})`);
+      params.push(`%${filters.search}%`);
+      paramIndex++;
+    }
+
+    const whereClause = conditions.join(' AND ');
+
+    // Allowlist for sort columns
+    const allowedSortColumns = ['created_at', 'action', 'resource_type', 'user_id'];
+    const safeSortBy = allowedSortColumns.includes(sortBy) ? sortBy : 'created_at';
+    const safeSortOrder = sortOrder === 'ASC' ? 'ASC' : 'DESC';
+
+    // Count total
+    const countResult = await this.platformService.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM audit_logs WHERE ${whereClause}`,
+      params,
+    );
+    const total = parseInt(countResult.rows[0]?.count || '0', 10);
+
+    // Fetch page
+    const dataResult = await this.platformService.query<any>(
+      `SELECT * FROM audit_logs WHERE ${whereClause} ORDER BY ${safeSortBy} ${safeSortOrder} LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      [...params, limit, offset],
+    );
+
+    const data = dataResult.rows.map(this.mapRow);
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  /**
+   * Get a single audit log entry by ID.
+   */
+  async getById(id: string, orgId: string): Promise<AuditLog | null> {
+    const result = await this.platformService.query<any>(
+      `SELECT * FROM audit_logs WHERE id = $1 AND organization_id = $2`,
+      [id, orgId],
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    return this.mapRow(result.rows[0]);
+  }
+
+  /**
+   * Get all audit entries for a specific resource.
+   */
+  async getByResource(
+    resourceType: string,
+    resourceId: string,
+    orgId: string,
+  ): Promise<AuditLog[]> {
+    const result = await this.platformService.query<any>(
+      `SELECT * FROM audit_logs WHERE resource_type = $1 AND resource_id = $2 AND organization_id = $3 ORDER BY created_at DESC`,
+      [resourceType, resourceId, orgId],
+    );
+
+    return result.rows.map(this.mapRow);
+  }
+
+  /**
+   * Map a database row (snake_case) to the AuditLog interface (camelCase).
+   */
+  private mapRow(row: any): AuditLog {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      organizationId: row.organization_id,
+      projectId: row.project_id,
+      action: row.action,
+      resourceType: row.resource_type,
+      resourceId: row.resource_id,
+      details: typeof row.details === 'string' ? JSON.parse(row.details) : (row.details || {}),
+      ipAddress: row.ip_address,
+      userAgent: row.user_agent,
+      createdAt: row.created_at,
+    };
+  }
+}

--- a/backend/src/modules/fluxturn/audit/index.ts
+++ b/backend/src/modules/fluxturn/audit/index.ts
@@ -1,0 +1,3 @@
+export { AuditModule } from './audit.module';
+export { AuditService, AuditAction } from './audit.service';
+export { AuditController } from './audit.controller';

--- a/backend/src/modules/fluxturn/workflow/workflow.module.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.module.ts
@@ -80,6 +80,7 @@ import { AvailableNodesSeederService } from './services/available-nodes-seeder.s
 import { NodesModule } from './nodes/nodes.module';
 import { WorkflowAgentsService } from './services/workflow-agents.service';
 import { OrchestratedGeneratorService } from './services/orchestrated-generator.service';
+import { AuditModule } from '../audit/audit.module';
 // import { TemplateSeederService } from './services/template-seeder.service';
 
 @Module({
@@ -92,6 +93,7 @@ import { OrchestratedGeneratorService } from './services/orchestrated-generator.
     forwardRef(() => ConnectorsModule),
     EventsModule,
     NodesModule,
+    AuditModule,
   ],
   controllers: [
     TemplateController, // Must be before WorkflowController to avoid route conflicts

--- a/backend/src/modules/fluxturn/workflow/workflow.service.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.service.ts
@@ -11,6 +11,7 @@ import { TriggerManagerService } from './services/trigger-manager.service';
 import { TriggerType } from './interfaces/trigger.interface';
 import { AIWorkflowGeneratorService } from './services/ai-workflow-generator.service';
 import { IntentDetectionService } from './services/intent-detection.service';
+import { AuditService } from '../audit/audit.service';
 // compareConnectorFields removed - seeding now done via npm run seed:connector
 
 @Injectable()
@@ -28,6 +29,7 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
     private triggerManager: TriggerManagerService,
     private aiWorkflowGenerator: AIWorkflowGeneratorService,
     private intentDetection: IntentDetectionService,
+    private auditService: AuditService,
   ) {}
 
   async onModuleInit() {
@@ -304,8 +306,27 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         }
       }
 
+      const created = result.rows[0];
+
+      // Audit log
+      this.auditService.log(
+        'workflow.created',
+        params.created_by,
+        'workflow',
+        created.id,
+        {
+          organizationId: params.organization_id,
+          projectId: params.project_id,
+          details: {
+            name: created.name,
+            isAiGenerated,
+            templateId: params.template_id || null,
+          },
+        },
+      ).catch(err => this.logger.warn('Audit log failed:', err.message));
+
       return {
-        ...result.rows[0],
+        ...created,
         confidence,
         generationStrategy: params.prompt ? 'hybrid' : 'manual'
       };
@@ -425,6 +446,21 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         ]);
 
         this.logger.log(`Workflow execution completed: ${executionId}`);
+
+        // Audit log
+        if (workflowRow.user_id || workflowRow.created_by) {
+          this.auditService.log(
+            'workflow.executed',
+            workflowRow.user_id || workflowRow.created_by,
+            'workflow',
+            params.workflow_id,
+            {
+              organizationId: workflowRow.organization_id,
+              projectId: workflowRow.project_id,
+              details: { executionId, status: 'completed' },
+            },
+          ).catch(err => this.logger.warn('Audit log failed:', err.message));
+        }
 
         return {
           ...executionResult.rows[0],
@@ -2181,6 +2217,23 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         };
       }
 
+      // Audit log
+      if (params.updated_by) {
+        this.auditService.log(
+          'workflow.updated',
+          params.updated_by,
+          'workflow',
+          workflowId,
+          {
+            organizationId: params.organization_id,
+            projectId: params.project_id,
+            details: {
+              updatedFields: Object.keys(params).filter(k => params[k] !== undefined && k !== 'updated_by' && k !== 'organization_id' && k !== 'project_id'),
+            },
+          },
+        ).catch(err => this.logger.warn('Audit log failed:', err.message));
+      }
+
       // Return workflow data with trigger results
       return {
         ...updatedWorkflow,
@@ -2236,9 +2289,25 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         throw new NotFoundException('Workflow not found');
       }
 
+      // Audit log
+      const deletedWorkflow = result.rows[0];
+      if (workflow?.user_id || workflow?.created_by) {
+        this.auditService.log(
+          'workflow.deleted',
+          workflow.user_id || workflow.created_by,
+          'workflow',
+          workflowId,
+          {
+            organizationId: organizationId,
+            projectId: projectId,
+            details: { name: deletedWorkflow.name },
+          },
+        ).catch(err => this.logger.warn('Audit log failed:', err.message));
+      }
+
       return {
         message: 'Workflow deleted successfully',
-        workflow: result.rows[0]
+        workflow: deletedWorkflow
       };
     } catch (error) {
       this.logger.error('Failed to delete workflow:', error);


### PR DESCRIPTION
## Summary
- Adds `AuditModule` in `backend/src/modules/fluxturn/audit/` with service, controller, and module
- Exposes `GET /audit-logs` (with filters + pagination), `GET /audit-logs/:id`, and `GET /audit-logs/resource/:type/:id` endpoints (org-scoped, authed)
- Filters: action, userId, resourceType, dateRange, search; Pagination: page, limit, sortBy, sortOrder
- Integrates audit logging into workflow CRUD: `workflow.created`, `workflow.updated`, `workflow.deleted`, `workflow.executed`
- Uses existing `PlatformService.createAuditLog()` for writes; adds dedicated query/filter layer on top

Closes #125

## Test plan
- [ ] Verify `npx tsc --noEmit` passes with 0 errors
- [ ] Create/update/delete/execute a workflow and verify audit_logs entries are written
- [ ] Test `GET /audit-logs` with x-organization-id header returns paginated results
- [ ] Test filtering by action, userId, resourceType, dateRange, and search
- [ ] Test `GET /audit-logs/:id` returns single entry
- [ ] Test `GET /audit-logs/resource/:type/:id` returns entries for a specific resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)