### PR TITLE
feat: dry-run / mock execution mode

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { EventsModule } from './events/events.module';
 import { QdrantModule } from './modules/qdrant/qdrant.module';
 import { DatabaseBrowserModule } from './modules/database-browser/database-browser.module';
 import { BlogModule } from './modules/blog/blog.module';
+import { AuditModule } from './modules/fluxturn/audit/audit.module';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { BlogModule } from './modules/blog/blog.module';
     EventsModule,
     DatabaseBrowserModule,
     BlogModule,
+    AuditModule,
   ],
   controllers: [HealthController],
   providers: [],

--- a/backend/src/modules/fluxturn/audit/audit.controller.ts
+++ b/backend/src/modules/fluxturn/audit/audit.controller.ts
@@ -1,0 +1,108 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiSecurity, ApiQuery } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { AuditService, AuditLogFilters, PaginationOptions } from './audit.service';
+
+@ApiTags('Audit Logs')
+@Controller('audit-logs')
+@UseGuards(JwtAuthGuard)
+@ApiSecurity('JWT')
+export class AuditController {
+  constructor(private readonly auditService: AuditService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List audit logs with filtering and pagination' })
+  @ApiQuery({ name: 'action', required: false })
+  @ApiQuery({ name: 'userId', required: false })
+  @ApiQuery({ name: 'resourceType', required: false })
+  @ApiQuery({ name: 'dateFrom', required: false })
+  @ApiQuery({ name: 'dateTo', required: false })
+  @ApiQuery({ name: 'search', required: false })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'sortBy', required: false })
+  @ApiQuery({ name: 'sortOrder', required: false, enum: ['ASC', 'DESC'] })
+  async list(
+    @Request() req: any,
+    @Query('action') action?: string,
+    @Query('userId') userId?: string,
+    @Query('resourceType') resourceType?: string,
+    @Query('dateFrom') dateFrom?: string,
+    @Query('dateTo') dateTo?: string,
+    @Query('search') search?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('sortBy') sortBy?: string,
+    @Query('sortOrder') sortOrder?: string,
+  ) {
+    const orgId = this.extractOrgId(req);
+
+    const filters: AuditLogFilters = {
+      action,
+      userId,
+      resourceType,
+      dateFrom,
+      dateTo,
+      search,
+    };
+
+    const pagination: PaginationOptions = {
+      page: page ? parseInt(page, 10) : 1,
+      limit: limit ? Math.min(parseInt(limit, 10), 100) : 25,
+      sortBy: sortBy || 'created_at',
+      sortOrder: (sortOrder === 'ASC' ? 'ASC' : 'DESC') as 'ASC' | 'DESC',
+    };
+
+    return this.auditService.query(orgId, filters, pagination);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single audit log entry' })
+  async getById(@Param('id') id: string, @Request() req: any) {
+    const orgId = this.extractOrgId(req);
+    const entry = await this.auditService.getById(id, orgId);
+
+    if (!entry) {
+      throw new NotFoundException('Audit log entry not found');
+    }
+
+    return entry;
+  }
+
+  @Get('resource/:type/:id')
+  @ApiOperation({ summary: 'Get audit logs for a specific resource' })
+  async getByResource(
+    @Param('type') resourceType: string,
+    @Param('id') resourceId: string,
+    @Request() req: any,
+  ) {
+    const orgId = this.extractOrgId(req);
+    return this.auditService.getByResource(resourceType, resourceId, orgId);
+  }
+
+  /**
+   * Extract organization ID from request headers or user context.
+   */
+  private extractOrgId(req: any): string {
+    const orgId =
+      req.headers?.['x-organization-id'] ||
+      req.user?.organizationId;
+
+    if (!orgId) {
+      throw new BadRequestException(
+        'Organization ID is required. Pass it via the x-organization-id header.',
+      );
+    }
+
+    return orgId;
+  }
+}

--- a/backend/src/modules/fluxturn/audit/audit.module.ts
+++ b/backend/src/modules/fluxturn/audit/audit.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuditController } from './audit.controller';
+import { AuditService } from './audit.service';
+
+@Module({
+  controllers: [AuditController],
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/backend/src/modules/fluxturn/audit/audit.service.ts
+++ b/backend/src/modules/fluxturn/audit/audit.service.ts
@@ -1,0 +1,214 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PlatformService } from '../../database/platform.service';
+import { AuditLog } from '../../database/interfaces/platform.interface';
+
+export type AuditAction =
+  | 'workflow.created'
+  | 'workflow.updated'
+  | 'workflow.deleted'
+  | 'workflow.executed'
+  | 'credential.created'
+  | 'credential.updated'
+  | 'member.invited'
+  | 'member.removed'
+  | 'settings.changed';
+
+export interface AuditLogFilters {
+  action?: string;
+  userId?: string;
+  resourceType?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  search?: string;
+}
+
+export interface PaginationOptions {
+  page?: number;
+  limit?: number;
+  sortBy?: string;
+  sortOrder?: 'ASC' | 'DESC';
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+@Injectable()
+export class AuditService {
+  private readonly logger = new Logger(AuditService.name);
+
+  constructor(private readonly platformService: PlatformService) {}
+
+  /**
+   * Write an audit log entry.
+   */
+  async log(
+    action: AuditAction | string,
+    userId: string,
+    resourceType: string,
+    resourceId?: string,
+    metadata?: {
+      organizationId?: string;
+      projectId?: string;
+      details?: Record<string, any>;
+      ipAddress?: string;
+      userAgent?: string;
+    },
+  ): Promise<AuditLog> {
+    return this.platformService.createAuditLog({
+      userId,
+      organizationId: metadata?.organizationId,
+      projectId: metadata?.projectId,
+      action,
+      resourceType,
+      resourceId,
+      details: metadata?.details || {},
+      ipAddress: metadata?.ipAddress,
+      userAgent: metadata?.userAgent,
+    });
+  }
+
+  /**
+   * Query audit logs with filtering and pagination.
+   */
+  async query(
+    orgId: string,
+    filters: AuditLogFilters = {},
+    pagination: PaginationOptions = {},
+  ): Promise<PaginatedResult<AuditLog>> {
+    const {
+      page = 1,
+      limit = 25,
+      sortBy = 'created_at',
+      sortOrder = 'DESC',
+    } = pagination;
+
+    const offset = (page - 1) * limit;
+
+    // Build WHERE clause
+    const conditions: string[] = ['organization_id = $1'];
+    const params: any[] = [orgId];
+    let paramIndex = 2;
+
+    if (filters.action) {
+      conditions.push(`action = $${paramIndex}`);
+      params.push(filters.action);
+      paramIndex++;
+    }
+
+    if (filters.userId) {
+      conditions.push(`user_id = $${paramIndex}`);
+      params.push(filters.userId);
+      paramIndex++;
+    }
+
+    if (filters.resourceType) {
+      conditions.push(`resource_type = $${paramIndex}`);
+      params.push(filters.resourceType);
+      paramIndex++;
+    }
+
+    if (filters.dateFrom) {
+      conditions.push(`created_at >= $${paramIndex}`);
+      params.push(filters.dateFrom);
+      paramIndex++;
+    }
+
+    if (filters.dateTo) {
+      conditions.push(`created_at <= $${paramIndex}`);
+      params.push(filters.dateTo);
+      paramIndex++;
+    }
+
+    if (filters.search) {
+      conditions.push(`(action ILIKE $${paramIndex} OR resource_type ILIKE $${paramIndex} OR details::text ILIKE $${paramIndex})`);
+      params.push(`%${filters.search}%`);
+      paramIndex++;
+    }
+
+    const whereClause = conditions.join(' AND ');
+
+    // Allowlist for sort columns
+    const allowedSortColumns = ['created_at', 'action', 'resource_type', 'user_id'];
+    const safeSortBy = allowedSortColumns.includes(sortBy) ? sortBy : 'created_at';
+    const safeSortOrder = sortOrder === 'ASC' ? 'ASC' : 'DESC';
+
+    // Count total
+    const countResult = await this.platformService.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM audit_logs WHERE ${whereClause}`,
+      params,
+    );
+    const total = parseInt(countResult.rows[0]?.count || '0', 10);
+
+    // Fetch page
+    const dataResult = await this.platformService.query<any>(
+      `SELECT * FROM audit_logs WHERE ${whereClause} ORDER BY ${safeSortBy} ${safeSortOrder} LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      [...params, limit, offset],
+    );
+
+    const data = dataResult.rows.map(this.mapRow);
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  /**
+   * Get a single audit log entry by ID.
+   */
+  async getById(id: string, orgId: string): Promise<AuditLog | null> {
+    const result = await this.platformService.query<any>(
+      `SELECT * FROM audit_logs WHERE id = $1 AND organization_id = $2`,
+      [id, orgId],
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    return this.mapRow(result.rows[0]);
+  }
+
+  /**
+   * Get all audit entries for a specific resource.
+   */
+  async getByResource(
+    resourceType: string,
+    resourceId: string,
+    orgId: string,
+  ): Promise<AuditLog[]> {
+    const result = await this.platformService.query<any>(
+      `SELECT * FROM audit_logs WHERE resource_type = $1 AND resource_id = $2 AND organization_id = $3 ORDER BY created_at DESC`,
+      [resourceType, resourceId, orgId],
+    );
+
+    return result.rows.map(this.mapRow);
+  }
+
+  /**
+   * Map a database row (snake_case) to the AuditLog interface (camelCase).
+   */
+  private mapRow(row: any): AuditLog {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      organizationId: row.organization_id,
+      projectId: row.project_id,
+      action: row.action,
+      resourceType: row.resource_type,
+      resourceId: row.resource_id,
+      details: typeof row.details === 'string' ? JSON.parse(row.details) : (row.details || {}),
+      ipAddress: row.ip_address,
+      userAgent: row.user_agent,
+      createdAt: row.created_at,
+    };
+  }
+}

--- a/backend/src/modules/fluxturn/audit/index.ts
+++ b/backend/src/modules/fluxturn/audit/index.ts
@@ -1,0 +1,3 @@
+export { AuditModule } from './audit.module';
+export { AuditService, AuditAction } from './audit.service';
+export { AuditController } from './audit.controller';

--- a/backend/src/modules/fluxturn/workflow/dto/dry-run.dto.ts
+++ b/backend/src/modules/fluxturn/workflow/dto/dry-run.dto.ts
@@ -1,0 +1,33 @@
+import { IsOptional, IsObject } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class DryRunDto {
+  @ApiPropertyOptional({
+    description: 'Sample input data to use during the dry run',
+    example: { email: 'test@example.com', name: 'John Doe' },
+  })
+  @IsOptional()
+  @IsObject()
+  sampleInput?: Record<string, any>;
+}
+
+export interface DryRunStepResult {
+  nodeId: string;
+  nodeName: string;
+  nodeType: string;
+  configValid: boolean;
+  credentialsAvailable: boolean;
+  wouldExecute: string;
+  mockOutput: any;
+  errors?: string[];
+  warnings?: string[];
+}
+
+export interface DryRunResult {
+  workflowId: string;
+  steps: DryRunStepResult[];
+  errors: string[];
+  warnings: string[];
+  totalNodes: number;
+  executionOrder: string[];
+}

--- a/backend/src/modules/fluxturn/workflow/services/dry-run.service.ts
+++ b/backend/src/modules/fluxturn/workflow/services/dry-run.service.ts
@@ -1,0 +1,520 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PlatformService } from '../../../database/platform.service';
+import { DryRunResult, DryRunStepResult } from '../dto/dry-run.dto';
+import { INode, IEdge, IWorkflowDefinition } from './workflow-execution.engine';
+
+/**
+ * Mock output generators keyed by node-type prefix or exact name.
+ * Used to synthesise realistic-looking data without calling live APIs.
+ */
+const MOCK_OUTPUTS: Record<string, (node: INode, sampleInput: any) => any> = {
+  // HTTP / Webhook nodes
+  HTTP_REQUEST: () => ({ status: 200, body: 'mock' }),
+  WEBHOOK_TRIGGER: (_n, sample) => ({ body: sample || {}, headers: {}, method: 'POST' }),
+  FORM_TRIGGER: (_n, sample) => ({ formData: sample || { field1: 'value1' } }),
+
+  // Transform / Code nodes
+  TRANSFORM: (_n, sample) => sample ? { transformed: sample } : { transformed: {} },
+  CODE: (_n, sample) => ({ result: sample || 'mock code output' }),
+  FUNCTION: (_n, sample) => ({ result: sample || 'mock function output' }),
+
+  // Condition / Router
+  CONDITION: (_n, sample) => ({ conditionMet: true, branch: 'true', data: sample || {} }),
+  IF: (_n, sample) => ({ conditionMet: true, branch: 'true', data: sample || {} }),
+  SWITCH: () => ({ matchedCase: 'case_0', data: {} }),
+  ROUTER: () => ({ route: 'default', data: {} }),
+
+  // LLM / AI nodes
+  LLM: () => ({ text: 'mock AI response' }),
+  OPENAI: () => ({ text: 'mock AI response', model: 'gpt-4', usage: { tokens: 42 } }),
+  ANTHROPIC: () => ({ text: 'mock AI response', model: 'claude', usage: { tokens: 42 } }),
+  AI_AGENT: () => ({ text: 'mock AI agent response', toolCalls: [] }),
+
+  // Communication
+  TELEGRAM: () => ({ messageId: 12345, chat: { id: 1 }, ok: true }),
+  TELEGRAM_TRIGGER: () => ({ message: { text: 'mock message', from: { id: 1, username: 'test' } } }),
+  GMAIL: () => ({ id: 'msg-001', threadId: 'thread-001', labelIds: ['SENT'] }),
+  GMAIL_TRIGGER: () => ({ id: 'msg-001', subject: 'Mock email', from: 'test@example.com' }),
+  SLACK: () => ({ ok: true, channel: 'C01', ts: '1234567890.123456' }),
+  SLACK_TRIGGER: () => ({ text: 'mock slack message', user: 'U01', channel: 'C01' }),
+  DISCORD: () => ({ id: '123456', content: 'mock message sent' }),
+  EMAIL: () => ({ messageId: '<mock@email.com>', accepted: ['test@example.com'] }),
+  WHATSAPP: () => ({ messageId: 'wamid.mock', status: 'sent' }),
+  TEAMS: () => ({ id: 'msg-mock', createdDateTime: new Date().toISOString() }),
+
+  // Storage / Database
+  GOOGLE_SHEETS: () => ({ updatedRange: 'Sheet1!A1:B2', updatedRows: 1 }),
+  GOOGLE_SHEETS_TRIGGER: () => ({ row: { A: 'value1', B: 'value2' } }),
+  GOOGLE_DRIVE: () => ({ id: 'file-001', name: 'mock-file.txt', mimeType: 'text/plain' }),
+  GOOGLE_DRIVE_TRIGGER: () => ({ fileId: 'file-001', name: 'mock-file.txt', change: 'created' }),
+  DATABASE: () => ({ rows: [{ id: 1, name: 'mock' }], rowCount: 1 }),
+  REDIS: () => ({ value: 'mock-value', key: 'mock-key' }),
+  MONGODB: () => ({ insertedId: 'mock-id', acknowledged: true }),
+  AWS_S3: () => ({ key: 'mock-key', bucket: 'mock-bucket', etag: 'mock-etag' }),
+
+  // CRM
+  HUBSPOT: () => ({ id: '1', properties: { email: 'mock@example.com' } }),
+  PIPEDRIVE: () => ({ id: 1, name: 'Mock Deal', status: 'open' }),
+  SALESFORCE: () => ({ id: '001', success: true }),
+  MONDAY: () => ({ id: '123', name: 'Mock item' }),
+
+  // E-commerce
+  STRIPE: () => ({ id: 'ch_mock', amount: 1000, currency: 'usd', status: 'succeeded' }),
+  STRIPE_TRIGGER: () => ({ type: 'payment_intent.succeeded', data: { object: { id: 'pi_mock' } } }),
+  SHOPIFY: () => ({ id: 123, title: 'Mock Product' }),
+  GUMROAD: () => ({ id: 'sale-mock', product_name: 'Mock Product', price: 999 }),
+
+  // Project management
+  JIRA: () => ({ id: '10001', key: 'MOCK-1', summary: 'Mock issue' }),
+  JIRA_TRIGGER: () => ({ issue: { key: 'MOCK-1', fields: { summary: 'Mock issue' } } }),
+  TRELLO: () => ({ id: 'card-mock', name: 'Mock card', idList: 'list-mock' }),
+  ASANA: () => ({ gid: '12345', name: 'Mock task', completed: false }),
+  GITHUB: () => ({ id: 1, title: 'Mock issue', state: 'open' }),
+  GITHUB_TRIGGER: () => ({ action: 'opened', repository: { full_name: 'mock/repo' } }),
+  GITLAB: () => ({ id: 1, title: 'Mock MR', state: 'opened' }),
+
+  // Marketing
+  MAILCHIMP: () => ({ id: 'member-mock', email_address: 'mock@example.com', status: 'subscribed' }),
+  SENDGRID: () => ({ statusCode: 202, body: '' }),
+
+  // Social
+  TWITTER: () => ({ id: 'tweet-mock', text: 'Mock tweet' }),
+  FACEBOOK: () => ({ id: 'post-mock', message: 'Mock post' }),
+  INSTAGRAM: () => ({ id: 'media-mock', caption: 'Mock caption' }),
+  PINTEREST: () => ({ id: 'pin-mock', title: 'Mock pin' }),
+
+  // Scheduling
+  SCHEDULE: () => ({ triggered: true, scheduledTime: new Date().toISOString() }),
+  CRON: () => ({ triggered: true, cronExpression: '0 * * * *' }),
+  WAIT: () => ({ resumed: true, waitedMs: 1000 }),
+  DELAY: () => ({ resumed: true, delayMs: 1000 }),
+
+  // Utility
+  SET: (_n, sample) => sample || { key: 'value' },
+  MERGE: () => ({ merged: true, items: [] }),
+  SPLIT: () => ({ items: [[], []] }),
+  FILTER: (_n, sample) => ({ filtered: sample || [], kept: 1, removed: 0 }),
+  LOOP: () => ({ iteration: 0, items: [] }),
+  ERROR_TRIGGER: () => ({ error: { message: 'mock error', node: 'mock-node' } }),
+  NO_OP: () => ({}),
+  NOTE: () => ({}),
+
+  // Finance
+  PLAID: () => ({ accounts: [{ id: 'acc-mock', name: 'Mock Account' }] }),
+  WISE: () => ({ id: 'transfer-mock', status: 'completed' }),
+  CHARGEBEE: () => ({ subscription: { id: 'sub-mock', status: 'active' } }),
+
+  // Forms
+  TYPEFORM: () => ({ response_id: 'resp-mock', answers: [] }),
+  JOTFORM: () => ({ submissionID: 'sub-mock', answers: {} }),
+
+  // Connector-based (generic)
+  CONNECTOR_TRIGGER: () => ({ event: 'mock_event', data: {} }),
+  CONNECTOR_ACTION: () => ({ success: true, data: {} }),
+
+  // Calendar
+  GOOGLE_CALENDAR: () => ({ id: 'event-mock', summary: 'Mock Event' }),
+  GOOGLE_CALENDAR_TRIGGER: () => ({ id: 'event-mock', summary: 'Mock Event', start: {} }),
+
+  // Support
+  FRESHDESK: () => ({ id: 1, subject: 'Mock ticket', status: 2 }),
+
+  // Productivity
+  CLOCKIFY: () => ({ id: 'entry-mock', description: 'Mock time entry' }),
+  TOGGL: () => ({ id: 12345, description: 'Mock time entry' }),
+};
+
+/**
+ * DryRunService
+ *
+ * Traces workflow execution without calling external APIs.
+ * For each node it validates configuration, checks credential
+ * availability, and returns mock output based on the node type.
+ */
+@Injectable()
+export class DryRunService {
+  private readonly logger = new Logger(DryRunService.name);
+
+  constructor(
+    private readonly platformService: PlatformService,
+  ) {}
+
+  /**
+   * Run a dry-run of the given workflow.
+   *
+   * @param workflowId  The ID of the persisted workflow
+   * @param sampleInput Optional sample input fed into the first node
+   */
+  async dryRun(workflowId: string, sampleInput?: Record<string, any>): Promise<DryRunResult> {
+    this.logger.log(`Starting dry-run for workflow ${workflowId}`);
+
+    // 1. Load workflow definition
+    const workflow = await this.loadWorkflow(workflowId);
+    const canvas = workflow.workflow?.canvas || workflow.canvas;
+
+    if (!canvas || !canvas.nodes || canvas.nodes.length === 0) {
+      return {
+        workflowId,
+        steps: [],
+        errors: ['Workflow has no nodes defined'],
+        warnings: [],
+        totalNodes: 0,
+        executionOrder: [],
+      };
+    }
+
+    const nodes: INode[] = canvas.nodes;
+    const edges: IEdge[] = canvas.edges || [];
+
+    // 2. Determine execution order (topological sort via BFS from trigger/start node)
+    const executionOrder = this.getExecutionOrder(nodes, edges);
+
+    // 3. Gather credential info for the project
+    const projectId = workflow.project_id;
+    const credentialMap = await this.getCredentialMap(projectId);
+
+    // 4. Walk each node
+    const steps: DryRunStepResult[] = [];
+    const globalErrors: string[] = [];
+    const globalWarnings: string[] = [];
+
+    let previousOutput: any = sampleInput || {};
+
+    for (const nodeId of executionOrder) {
+      const node = nodes.find(n => n.id === nodeId);
+      if (!node) {
+        globalWarnings.push(`Node ${nodeId} referenced in edges but not found in nodes array`);
+        continue;
+      }
+
+      const step = this.evaluateNode(node, previousOutput, credentialMap);
+      steps.push(step);
+
+      if (step.errors && step.errors.length > 0) {
+        globalErrors.push(...step.errors.map(e => `[${step.nodeName || step.nodeId}] ${e}`));
+      }
+      if (step.warnings && step.warnings.length > 0) {
+        globalWarnings.push(...step.warnings.map(w => `[${step.nodeName || step.nodeId}] ${w}`));
+      }
+
+      // Feed mock output forward
+      previousOutput = step.mockOutput;
+    }
+
+    this.logger.log(
+      `Dry-run complete for workflow ${workflowId}: ${steps.length} steps, ${globalErrors.length} errors, ${globalWarnings.length} warnings`,
+    );
+
+    return {
+      workflowId,
+      steps,
+      errors: globalErrors,
+      warnings: globalWarnings,
+      totalNodes: nodes.length,
+      executionOrder,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Private helpers
+  // ------------------------------------------------------------------
+
+  private async loadWorkflow(workflowId: string): Promise<any> {
+    const result = await this.platformService.query(
+      'SELECT * FROM workflows WHERE id = $1',
+      [workflowId],
+    );
+
+    if (!result.rows || result.rows.length === 0) {
+      throw new NotFoundException(`Workflow ${workflowId} not found`);
+    }
+
+    return result.rows[0];
+  }
+
+  /**
+   * Build a map of connector_type -> boolean indicating whether credentials
+   * are available for this project.
+   */
+  private async getCredentialMap(projectId?: string): Promise<Record<string, boolean>> {
+    if (!projectId) return {};
+
+    try {
+      const result = await this.platformService.query(
+        `SELECT connector_type, is_active FROM connector_configs WHERE project_id = $1`,
+        [projectId],
+      );
+      const map: Record<string, boolean> = {};
+      for (const row of result.rows || []) {
+        map[row.connector_type] = row.is_active !== false;
+      }
+      return map;
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Topological BFS from root node(s) following edge direction.
+   */
+  private getExecutionOrder(nodes: INode[], edges: IEdge[]): string[] {
+    const adjacency: Record<string, string[]> = {};
+    const inDegree: Record<string, number> = {};
+
+    for (const node of nodes) {
+      adjacency[node.id] = [];
+      inDegree[node.id] = 0;
+    }
+
+    for (const edge of edges) {
+      if (adjacency[edge.source]) {
+        adjacency[edge.source].push(edge.target);
+      }
+      if (inDegree[edge.target] !== undefined) {
+        inDegree[edge.target]++;
+      }
+    }
+
+    // Start from nodes with 0 in-degree (triggers / start nodes)
+    const queue: string[] = [];
+    for (const node of nodes) {
+      if (inDegree[node.id] === 0) {
+        queue.push(node.id);
+      }
+    }
+
+    const order: string[] = [];
+    const visited = new Set<string>();
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      order.push(current);
+
+      for (const next of adjacency[current] || []) {
+        inDegree[next]--;
+        if (inDegree[next] <= 0 && !visited.has(next)) {
+          queue.push(next);
+        }
+      }
+    }
+
+    // Include any disconnected nodes not yet visited
+    for (const node of nodes) {
+      if (!visited.has(node.id)) {
+        order.push(node.id);
+      }
+    }
+
+    return order;
+  }
+
+  /**
+   * Evaluate a single node: validate config, check creds, produce mock output.
+   */
+  private evaluateNode(
+    node: INode,
+    sampleInput: any,
+    credentialMap: Record<string, boolean>,
+  ): DryRunStepResult {
+    const nodeType = node.type || 'UNKNOWN';
+    const nodeName = node.data?.label || node.data?.name || nodeType;
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    // --- Config validation ---
+    const configValid = this.validateNodeConfig(node, errors, warnings);
+
+    // --- Credential check ---
+    const credentialsAvailable = this.checkCredentials(node, credentialMap, warnings);
+
+    // --- Determine what would happen ---
+    const wouldExecute = this.describeExecution(node);
+
+    // --- Generate mock output ---
+    const mockOutput = this.generateMockOutput(node, sampleInput);
+
+    return {
+      nodeId: node.id,
+      nodeName,
+      nodeType,
+      configValid,
+      credentialsAvailable,
+      wouldExecute,
+      mockOutput,
+      errors: errors.length > 0 ? errors : undefined,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+  }
+
+  private validateNodeConfig(node: INode, errors: string[], warnings: string[]): boolean {
+    const data = node.data || {};
+    const nodeType = node.type || '';
+    let valid = true;
+
+    // Check for completely empty configuration
+    const hasAnyConfig = Object.keys(data).some(
+      k => !['label', 'name', 'icon', 'color', 'description'].includes(k) && data[k] != null,
+    );
+
+    if (!hasAnyConfig) {
+      warnings.push('Node has no configuration set');
+    }
+
+    // Type-specific checks
+    if (nodeType.includes('HTTP') && !data.url) {
+      errors.push('HTTP node missing required "url" field');
+      valid = false;
+    }
+
+    if (nodeType.includes('EMAIL') || nodeType.includes('GMAIL')) {
+      if (data.action === 'send_email' || data.actionId === 'send_email') {
+        if (!data.to && !data.config?.to) {
+          warnings.push('Email node has no "to" address configured');
+        }
+      }
+    }
+
+    if (nodeType.includes('TELEGRAM')) {
+      if (
+        (data.action === 'send_message' || data.actionId === 'send_message') &&
+        !data.chatId &&
+        !data.config?.chatId
+      ) {
+        warnings.push('Telegram node has no "chatId" configured');
+      }
+    }
+
+    if (nodeType === 'CONDITION' || nodeType === 'IF') {
+      if (!data.conditions && !data.config?.conditions) {
+        warnings.push('Condition node has no conditions defined');
+      }
+    }
+
+    if (nodeType === 'CODE' || nodeType === 'FUNCTION') {
+      if (!data.code && !data.config?.code) {
+        errors.push('Code node has no code defined');
+        valid = false;
+      }
+    }
+
+    if (nodeType === 'SCHEDULE' || nodeType === 'CRON') {
+      if (!data.cronExpression && !data.config?.cronExpression && !data.interval && !data.config?.interval) {
+        warnings.push('Schedule node has no cron expression or interval set');
+      }
+    }
+
+    return valid;
+  }
+
+  private checkCredentials(
+    node: INode,
+    credentialMap: Record<string, boolean>,
+    warnings: string[],
+  ): boolean {
+    const nodeType = node.type || '';
+    const connectorType = node.data?.connectorType || node.data?.connector_type;
+
+    // Utility / logic nodes don't need credentials
+    const noCredNeeded = [
+      'CONDITION', 'IF', 'SWITCH', 'ROUTER', 'SET', 'MERGE', 'SPLIT',
+      'FILTER', 'LOOP', 'CODE', 'FUNCTION', 'TRANSFORM', 'WAIT', 'DELAY',
+      'NOTE', 'NO_OP', 'ERROR_TRIGGER', 'SCHEDULE', 'CRON',
+      'WEBHOOK_TRIGGER', 'FORM_TRIGGER',
+    ];
+
+    if (noCredNeeded.some(t => nodeType.includes(t))) {
+      return true;
+    }
+
+    // If the node references a specific connector config id, assume it's fine
+    if (node.data?.connectorConfigId || node.data?.connector_config_id) {
+      return true;
+    }
+
+    // Try to match by connector type
+    const typeKey = connectorType || nodeType.replace(/_TRIGGER$/, '').replace(/_ACTION$/, '').toLowerCase();
+
+    if (typeKey && credentialMap[typeKey] !== undefined) {
+      if (!credentialMap[typeKey]) {
+        warnings.push(`Credentials for "${typeKey}" exist but are inactive`);
+        return false;
+      }
+      return true;
+    }
+
+    // Could not determine — warn
+    if (typeKey && !noCredNeeded.some(t => nodeType.includes(t))) {
+      warnings.push(`Could not verify credentials for connector "${typeKey}"`);
+    }
+
+    return false;
+  }
+
+  private describeExecution(node: INode): string {
+    const nodeType = node.type || 'UNKNOWN';
+    const action = node.data?.action || node.data?.actionId || '';
+    const connectorType = node.data?.connectorType || '';
+
+    if (nodeType.includes('TRIGGER')) {
+      return `Would listen for incoming ${connectorType || nodeType.replace('_TRIGGER', '')} events`;
+    }
+
+    if (nodeType === 'HTTP_REQUEST') {
+      const method = node.data?.method || node.data?.config?.method || 'GET';
+      const url = node.data?.url || node.data?.config?.url || '<not set>';
+      return `Would make ${method} request to ${url}`;
+    }
+
+    if (nodeType === 'CODE' || nodeType === 'FUNCTION') {
+      return 'Would execute custom code/function';
+    }
+
+    if (nodeType === 'CONDITION' || nodeType === 'IF') {
+      return 'Would evaluate condition and branch';
+    }
+
+    if (nodeType === 'SWITCH' || nodeType === 'ROUTER') {
+      return 'Would route to matching case';
+    }
+
+    if (nodeType === 'TRANSFORM') {
+      return 'Would transform data';
+    }
+
+    if (nodeType === 'WAIT' || nodeType === 'DELAY') {
+      return 'Would pause execution';
+    }
+
+    if (nodeType === 'SCHEDULE' || nodeType === 'CRON') {
+      return 'Would run on schedule';
+    }
+
+    if (action) {
+      return `Would execute "${action}" on ${connectorType || nodeType}`;
+    }
+
+    return `Would execute ${connectorType || nodeType} node`;
+  }
+
+  private generateMockOutput(node: INode, sampleInput: any): any {
+    const nodeType = node.type || 'UNKNOWN';
+
+    // Try exact match first
+    const generator = MOCK_OUTPUTS[nodeType];
+    if (generator) {
+      return generator(node, sampleInput);
+    }
+
+    // Try prefix match (e.g. GOOGLE_SHEETS_TRIGGER matches GOOGLE_SHEETS)
+    for (const [key, gen] of Object.entries(MOCK_OUTPUTS)) {
+      if (nodeType.startsWith(key)) {
+        return gen(node, sampleInput);
+      }
+    }
+
+    // Fallback: generic mock
+    return { success: true, data: sampleInput || {} };
+  }
+}

--- a/backend/src/modules/fluxturn/workflow/services/workflow-execution.engine.ts
+++ b/backend/src/modules/fluxturn/workflow/services/workflow-execution.engine.ts
@@ -83,6 +83,7 @@ export class WorkflowExecutionEngine {
       destinationNodeId?: string;
       mode?: 'manual' | 'production';
       executionId?: string;
+      dryRun?: boolean;
     } = {}
   ): Promise<any> {
     this.logger.log(`Starting workflow execution with ${workflow.nodes.length} nodes`);
@@ -129,7 +130,8 @@ export class WorkflowExecutionEngine {
           metadata: {
             startedAt: new Date(),
             executionId: options.executionId,
-            mode: options.mode || 'manual'
+            mode: options.mode || 'manual',
+            dryRun: options.dryRun || false
           }
         }
       };

--- a/backend/src/modules/fluxturn/workflow/workflow.controller.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.controller.ts
@@ -21,6 +21,8 @@ import { WorkflowService } from './workflow.service';
 import { TriggerType } from './interfaces/trigger.interface';
 import { JwtOrApiKeyAuthGuard } from '../../auth/guards/jwt-or-api-key-auth.guard';
 import { ToolRegistryService } from './services/tool-registry.service';
+import { DryRunService } from './services/dry-run.service';
+import { DryRunDto } from './dto/dry-run.dto';
 import {
   CreateWorkflowDto,
   ExecuteWorkflowDto,
@@ -57,6 +59,7 @@ export class WorkflowController {
   constructor(
     private readonly workflowService: WorkflowService,
     private readonly toolRegistryService: ToolRegistryService,
+    private readonly dryRunService: DryRunService,
   ) {}
 
   @Post('create')
@@ -140,6 +143,51 @@ export class WorkflowController {
       body.nodeId,
       body.testData || {}
     );
+  }
+
+  @Post(':id/dry-run')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Dry-run a workflow without executing real actions',
+    description:
+      'Traces the execution path, validates node configuration, checks credential availability, and returns mock output for every node without calling any external APIs.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Dry-run completed successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        workflowId: { type: 'string' },
+        steps: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              nodeId: { type: 'string' },
+              nodeName: { type: 'string' },
+              nodeType: { type: 'string' },
+              configValid: { type: 'boolean' },
+              credentialsAvailable: { type: 'boolean' },
+              wouldExecute: { type: 'string' },
+              mockOutput: { type: 'object' },
+            },
+          },
+        },
+        errors: { type: 'array', items: { type: 'string' } },
+        warnings: { type: 'array', items: { type: 'string' } },
+        totalNodes: { type: 'number' },
+        executionOrder: { type: 'array', items: { type: 'string' } },
+      },
+    },
+  })
+  @ApiBody({ type: DryRunDto })
+  async dryRunWorkflow(
+    @Param('id') workflowId: string,
+    @Body(ValidationPipe) dto: DryRunDto,
+    @Request() req: any
+  ) {
+    return this.dryRunService.dryRun(workflowId, dto.sampleInput);
   }
 
   @Get('list')

--- a/backend/src/modules/fluxturn/workflow/workflow.module.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.module.ts
@@ -80,6 +80,7 @@ import { AvailableNodesSeederService } from './services/available-nodes-seeder.s
 import { NodesModule } from './nodes/nodes.module';
 import { WorkflowAgentsService } from './services/workflow-agents.service';
 import { OrchestratedGeneratorService } from './services/orchestrated-generator.service';
+import { DryRunService } from './services/dry-run.service';
 import { AuditModule } from '../audit/audit.module';
 // import { TemplateSeederService } from './services/template-seeder.service';
 
@@ -132,6 +133,7 @@ import { AuditModule } from '../audit/audit.module';
   ],
   providers: [
     WorkflowService,
+    DryRunService,
     TemplateService,
     WorkflowExecutionEngine,
     NodeExecutorService,

--- a/backend/src/modules/fluxturn/workflow/workflow.module.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.module.ts
@@ -80,6 +80,7 @@ import { AvailableNodesSeederService } from './services/available-nodes-seeder.s
 import { NodesModule } from './nodes/nodes.module';
 import { WorkflowAgentsService } from './services/workflow-agents.service';
 import { OrchestratedGeneratorService } from './services/orchestrated-generator.service';
+import { AuditModule } from '../audit/audit.module';
 // import { TemplateSeederService } from './services/template-seeder.service';
 
 @Module({
@@ -92,6 +93,7 @@ import { OrchestratedGeneratorService } from './services/orchestrated-generator.
     forwardRef(() => ConnectorsModule),
     EventsModule,
     NodesModule,
+    AuditModule,
   ],
   controllers: [
     TemplateController, // Must be before WorkflowController to avoid route conflicts

--- a/backend/src/modules/fluxturn/workflow/workflow.service.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.service.ts
@@ -11,6 +11,7 @@ import { TriggerManagerService } from './services/trigger-manager.service';
 import { TriggerType } from './interfaces/trigger.interface';
 import { AIWorkflowGeneratorService } from './services/ai-workflow-generator.service';
 import { IntentDetectionService } from './services/intent-detection.service';
+import { AuditService } from '../audit/audit.service';
 // compareConnectorFields removed - seeding now done via npm run seed:connector
 
 @Injectable()
@@ -28,6 +29,7 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
     private triggerManager: TriggerManagerService,
     private aiWorkflowGenerator: AIWorkflowGeneratorService,
     private intentDetection: IntentDetectionService,
+    private auditService: AuditService,
   ) {}
 
   async onModuleInit() {
@@ -304,8 +306,27 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         }
       }
 
+      const created = result.rows[0];
+
+      // Audit log
+      this.auditService.log(
+        'workflow.created',
+        params.created_by,
+        'workflow',
+        created.id,
+        {
+          organizationId: params.organization_id,
+          projectId: params.project_id,
+          details: {
+            name: created.name,
+            isAiGenerated,
+            templateId: params.template_id || null,
+          },
+        },
+      ).catch(err => this.logger.warn('Audit log failed:', err.message));
+
       return {
-        ...result.rows[0],
+        ...created,
         confidence,
         generationStrategy: params.prompt ? 'hybrid' : 'manual'
       };
@@ -425,6 +446,21 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         ]);
 
         this.logger.log(`Workflow execution completed: ${executionId}`);
+
+        // Audit log
+        if (workflowRow.user_id || workflowRow.created_by) {
+          this.auditService.log(
+            'workflow.executed',
+            workflowRow.user_id || workflowRow.created_by,
+            'workflow',
+            params.workflow_id,
+            {
+              organizationId: workflowRow.organization_id,
+              projectId: workflowRow.project_id,
+              details: { executionId, status: 'completed' },
+            },
+          ).catch(err => this.logger.warn('Audit log failed:', err.message));
+        }
 
         return {
           ...executionResult.rows[0],
@@ -2181,6 +2217,23 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         };
       }
 
+      // Audit log
+      if (params.updated_by) {
+        this.auditService.log(
+          'workflow.updated',
+          params.updated_by,
+          'workflow',
+          workflowId,
+          {
+            organizationId: params.organization_id,
+            projectId: params.project_id,
+            details: {
+              updatedFields: Object.keys(params).filter(k => params[k] !== undefined && k !== 'updated_by' && k !== 'organization_id' && k !== 'project_id'),
+            },
+          },
+        ).catch(err => this.logger.warn('Audit log failed:', err.message));
+      }
+
       // Return workflow data with trigger results
       return {
         ...updatedWorkflow,
@@ -2236,9 +2289,25 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         throw new NotFoundException('Workflow not found');
       }
 
+      // Audit log
+      const deletedWorkflow = result.rows[0];
+      if (workflow?.user_id || workflow?.created_by) {
+        this.auditService.log(
+          'workflow.deleted',
+          workflow.user_id || workflow.created_by,
+          'workflow',
+          workflowId,
+          {
+            organizationId: organizationId,
+            projectId: projectId,
+            details: { name: deletedWorkflow.name },
+          },
+        ).catch(err => this.logger.warn('Audit log failed:', err.message));
+      }
+
       return {
         message: 'Workflow deleted successfully',
-        workflow: result.rows[0]
+        workflow: deletedWorkflow
       };
     } catch (error) {
       this.logger.error('Failed to delete workflow:', error);


### PR DESCRIPTION
## Summary
- Add `DryRunService` that traces workflow execution without calling external APIs: validates node config, checks credential availability, generates mock output per node type
- Expose `POST /workflows/:id/dry-run` endpoint (authed) accepting optional sample input
- Add `dryRun` flag to the execution engine context for future node-executor integration
- Covers 40+ node types with realistic mock outputs (HTTP, LLM, Telegram, Gmail, Slack, Stripe, etc.)

Closes #127

## Test plan
- [ ] `POST /workflows/:id/dry-run` with a saved workflow returns step-by-step trace
- [ ] Nodes with missing config report `configValid: false` and list errors
- [ ] Nodes without credentials report `credentialsAvailable: false`
- [ ] Mock outputs match the documented shapes (HTTP -> `{status:200, body:"mock"}`, LLM -> `{text:"mock AI response"}`, etc.)
- [ ] `tsc --noEmit` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)