### PR TITLE
feat: external secrets management with provider abstraction

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -25,6 +25,7 @@ import { QdrantModule } from './modules/qdrant/qdrant.module';
 import { DatabaseBrowserModule } from './modules/database-browser/database-browser.module';
 import { BlogModule } from './modules/blog/blog.module';
 import { AuditModule } from './modules/fluxturn/audit/audit.module';
+import { SecretsModule } from './modules/secrets/secrets.module';
 
 @Module({
   imports: [
@@ -62,6 +63,7 @@ import { AuditModule } from './modules/fluxturn/audit/audit.module';
     DatabaseBrowserModule,
     BlogModule,
     AuditModule,
+    SecretsModule,
   ],
   controllers: [HealthController],
   providers: [],

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { EventsModule } from './events/events.module';
 import { QdrantModule } from './modules/qdrant/qdrant.module';
 import { DatabaseBrowserModule } from './modules/database-browser/database-browser.module';
 import { BlogModule } from './modules/blog/blog.module';
+import { AuditModule } from './modules/fluxturn/audit/audit.module';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { BlogModule } from './modules/blog/blog.module';
     EventsModule,
     DatabaseBrowserModule,
     BlogModule,
+    AuditModule,
   ],
   controllers: [HealthController],
   providers: [],

--- a/backend/src/modules/fluxturn/audit/audit.controller.ts
+++ b/backend/src/modules/fluxturn/audit/audit.controller.ts
@@ -1,0 +1,108 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiSecurity, ApiQuery } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { AuditService, AuditLogFilters, PaginationOptions } from './audit.service';
+
+@ApiTags('Audit Logs')
+@Controller('audit-logs')
+@UseGuards(JwtAuthGuard)
+@ApiSecurity('JWT')
+export class AuditController {
+  constructor(private readonly auditService: AuditService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List audit logs with filtering and pagination' })
+  @ApiQuery({ name: 'action', required: false })
+  @ApiQuery({ name: 'userId', required: false })
+  @ApiQuery({ name: 'resourceType', required: false })
+  @ApiQuery({ name: 'dateFrom', required: false })
+  @ApiQuery({ name: 'dateTo', required: false })
+  @ApiQuery({ name: 'search', required: false })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'sortBy', required: false })
+  @ApiQuery({ name: 'sortOrder', required: false, enum: ['ASC', 'DESC'] })
+  async list(
+    @Request() req: any,
+    @Query('action') action?: string,
+    @Query('userId') userId?: string,
+    @Query('resourceType') resourceType?: string,
+    @Query('dateFrom') dateFrom?: string,
+    @Query('dateTo') dateTo?: string,
+    @Query('search') search?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('sortBy') sortBy?: string,
+    @Query('sortOrder') sortOrder?: string,
+  ) {
+    const orgId = this.extractOrgId(req);
+
+    const filters: AuditLogFilters = {
+      action,
+      userId,
+      resourceType,
+      dateFrom,
+      dateTo,
+      search,
+    };
+
+    const pagination: PaginationOptions = {
+      page: page ? parseInt(page, 10) : 1,
+      limit: limit ? Math.min(parseInt(limit, 10), 100) : 25,
+      sortBy: sortBy || 'created_at',
+      sortOrder: (sortOrder === 'ASC' ? 'ASC' : 'DESC') as 'ASC' | 'DESC',
+    };
+
+    return this.auditService.query(orgId, filters, pagination);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single audit log entry' })
+  async getById(@Param('id') id: string, @Request() req: any) {
+    const orgId = this.extractOrgId(req);
+    const entry = await this.auditService.getById(id, orgId);
+
+    if (!entry) {
+      throw new NotFoundException('Audit log entry not found');
+    }
+
+    return entry;
+  }
+
+  @Get('resource/:type/:id')
+  @ApiOperation({ summary: 'Get audit logs for a specific resource' })
+  async getByResource(
+    @Param('type') resourceType: string,
+    @Param('id') resourceId: string,
+    @Request() req: any,
+  ) {
+    const orgId = this.extractOrgId(req);
+    return this.auditService.getByResource(resourceType, resourceId, orgId);
+  }
+
+  /**
+   * Extract organization ID from request headers or user context.
+   */
+  private extractOrgId(req: any): string {
+    const orgId =
+      req.headers?.['x-organization-id'] ||
+      req.user?.organizationId;
+
+    if (!orgId) {
+      throw new BadRequestException(
+        'Organization ID is required. Pass it via the x-organization-id header.',
+      );
+    }
+
+    return orgId;
+  }
+}

--- a/backend/src/modules/fluxturn/audit/audit.module.ts
+++ b/backend/src/modules/fluxturn/audit/audit.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuditController } from './audit.controller';
+import { AuditService } from './audit.service';
+
+@Module({
+  controllers: [AuditController],
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/backend/src/modules/fluxturn/audit/audit.service.ts
+++ b/backend/src/modules/fluxturn/audit/audit.service.ts
@@ -1,0 +1,214 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PlatformService } from '../../database/platform.service';
+import { AuditLog } from '../../database/interfaces/platform.interface';
+
+export type AuditAction =
+  | 'workflow.created'
+  | 'workflow.updated'
+  | 'workflow.deleted'
+  | 'workflow.executed'
+  | 'credential.created'
+  | 'credential.updated'
+  | 'member.invited'
+  | 'member.removed'
+  | 'settings.changed';
+
+export interface AuditLogFilters {
+  action?: string;
+  userId?: string;
+  resourceType?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  search?: string;
+}
+
+export interface PaginationOptions {
+  page?: number;
+  limit?: number;
+  sortBy?: string;
+  sortOrder?: 'ASC' | 'DESC';
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+@Injectable()
+export class AuditService {
+  private readonly logger = new Logger(AuditService.name);
+
+  constructor(private readonly platformService: PlatformService) {}
+
+  /**
+   * Write an audit log entry.
+   */
+  async log(
+    action: AuditAction | string,
+    userId: string,
+    resourceType: string,
+    resourceId?: string,
+    metadata?: {
+      organizationId?: string;
+      projectId?: string;
+      details?: Record<string, any>;
+      ipAddress?: string;
+      userAgent?: string;
+    },
+  ): Promise<AuditLog> {
+    return this.platformService.createAuditLog({
+      userId,
+      organizationId: metadata?.organizationId,
+      projectId: metadata?.projectId,
+      action,
+      resourceType,
+      resourceId,
+      details: metadata?.details || {},
+      ipAddress: metadata?.ipAddress,
+      userAgent: metadata?.userAgent,
+    });
+  }
+
+  /**
+   * Query audit logs with filtering and pagination.
+   */
+  async query(
+    orgId: string,
+    filters: AuditLogFilters = {},
+    pagination: PaginationOptions = {},
+  ): Promise<PaginatedResult<AuditLog>> {
+    const {
+      page = 1,
+      limit = 25,
+      sortBy = 'created_at',
+      sortOrder = 'DESC',
+    } = pagination;
+
+    const offset = (page - 1) * limit;
+
+    // Build WHERE clause
+    const conditions: string[] = ['organization_id = $1'];
+    const params: any[] = [orgId];
+    let paramIndex = 2;
+
+    if (filters.action) {
+      conditions.push(`action = $${paramIndex}`);
+      params.push(filters.action);
+      paramIndex++;
+    }
+
+    if (filters.userId) {
+      conditions.push(`user_id = $${paramIndex}`);
+      params.push(filters.userId);
+      paramIndex++;
+    }
+
+    if (filters.resourceType) {
+      conditions.push(`resource_type = $${paramIndex}`);
+      params.push(filters.resourceType);
+      paramIndex++;
+    }
+
+    if (filters.dateFrom) {
+      conditions.push(`created_at >= $${paramIndex}`);
+      params.push(filters.dateFrom);
+      paramIndex++;
+    }
+
+    if (filters.dateTo) {
+      conditions.push(`created_at <= $${paramIndex}`);
+      params.push(filters.dateTo);
+      paramIndex++;
+    }
+
+    if (filters.search) {
+      conditions.push(`(action ILIKE $${paramIndex} OR resource_type ILIKE $${paramIndex} OR details::text ILIKE $${paramIndex})`);
+      params.push(`%${filters.search}%`);
+      paramIndex++;
+    }
+
+    const whereClause = conditions.join(' AND ');
+
+    // Allowlist for sort columns
+    const allowedSortColumns = ['created_at', 'action', 'resource_type', 'user_id'];
+    const safeSortBy = allowedSortColumns.includes(sortBy) ? sortBy : 'created_at';
+    const safeSortOrder = sortOrder === 'ASC' ? 'ASC' : 'DESC';
+
+    // Count total
+    const countResult = await this.platformService.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM audit_logs WHERE ${whereClause}`,
+      params,
+    );
+    const total = parseInt(countResult.rows[0]?.count || '0', 10);
+
+    // Fetch page
+    const dataResult = await this.platformService.query<any>(
+      `SELECT * FROM audit_logs WHERE ${whereClause} ORDER BY ${safeSortBy} ${safeSortOrder} LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      [...params, limit, offset],
+    );
+
+    const data = dataResult.rows.map(this.mapRow);
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  /**
+   * Get a single audit log entry by ID.
+   */
+  async getById(id: string, orgId: string): Promise<AuditLog | null> {
+    const result = await this.platformService.query<any>(
+      `SELECT * FROM audit_logs WHERE id = $1 AND organization_id = $2`,
+      [id, orgId],
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    return this.mapRow(result.rows[0]);
+  }
+
+  /**
+   * Get all audit entries for a specific resource.
+   */
+  async getByResource(
+    resourceType: string,
+    resourceId: string,
+    orgId: string,
+  ): Promise<AuditLog[]> {
+    const result = await this.platformService.query<any>(
+      `SELECT * FROM audit_logs WHERE resource_type = $1 AND resource_id = $2 AND organization_id = $3 ORDER BY created_at DESC`,
+      [resourceType, resourceId, orgId],
+    );
+
+    return result.rows.map(this.mapRow);
+  }
+
+  /**
+   * Map a database row (snake_case) to the AuditLog interface (camelCase).
+   */
+  private mapRow(row: any): AuditLog {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      organizationId: row.organization_id,
+      projectId: row.project_id,
+      action: row.action,
+      resourceType: row.resource_type,
+      resourceId: row.resource_id,
+      details: typeof row.details === 'string' ? JSON.parse(row.details) : (row.details || {}),
+      ipAddress: row.ip_address,
+      userAgent: row.user_agent,
+      createdAt: row.created_at,
+    };
+  }
+}

--- a/backend/src/modules/fluxturn/audit/index.ts
+++ b/backend/src/modules/fluxturn/audit/index.ts
@@ -1,0 +1,3 @@
+export { AuditModule } from './audit.module';
+export { AuditService, AuditAction } from './audit.service';
+export { AuditController } from './audit.controller';

--- a/backend/src/modules/fluxturn/workflow/dto/dry-run.dto.ts
+++ b/backend/src/modules/fluxturn/workflow/dto/dry-run.dto.ts
@@ -1,0 +1,33 @@
+import { IsOptional, IsObject } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class DryRunDto {
+  @ApiPropertyOptional({
+    description: 'Sample input data to use during the dry run',
+    example: { email: 'test@example.com', name: 'John Doe' },
+  })
+  @IsOptional()
+  @IsObject()
+  sampleInput?: Record<string, any>;
+}
+
+export interface DryRunStepResult {
+  nodeId: string;
+  nodeName: string;
+  nodeType: string;
+  configValid: boolean;
+  credentialsAvailable: boolean;
+  wouldExecute: string;
+  mockOutput: any;
+  errors?: string[];
+  warnings?: string[];
+}
+
+export interface DryRunResult {
+  workflowId: string;
+  steps: DryRunStepResult[];
+  errors: string[];
+  warnings: string[];
+  totalNodes: number;
+  executionOrder: string[];
+}

--- a/backend/src/modules/fluxturn/workflow/nodes/base/base-node.executor.ts
+++ b/backend/src/modules/fluxturn/workflow/nodes/base/base-node.executor.ts
@@ -113,6 +113,12 @@ export abstract class BaseNodeExecutor implements INodeExecutor {
       return context.$env?.[varName] || process.env[varName];
     }
 
+    // Handle secrets.NAME - resolved by SecretsService at the engine level
+    // This returns a placeholder; actual resolution happens in WorkflowExecutionEngine
+    if (path.startsWith('secrets.')) {
+      return `{{${path}}}`;
+    }
+
     // Fallback: return as literal
     return path;
   }

--- a/backend/src/modules/fluxturn/workflow/services/dry-run.service.ts
+++ b/backend/src/modules/fluxturn/workflow/services/dry-run.service.ts
@@ -1,0 +1,520 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PlatformService } from '../../../database/platform.service';
+import { DryRunResult, DryRunStepResult } from '../dto/dry-run.dto';
+import { INode, IEdge, IWorkflowDefinition } from './workflow-execution.engine';
+
+/**
+ * Mock output generators keyed by node-type prefix or exact name.
+ * Used to synthesise realistic-looking data without calling live APIs.
+ */
+const MOCK_OUTPUTS: Record<string, (node: INode, sampleInput: any) => any> = {
+  // HTTP / Webhook nodes
+  HTTP_REQUEST: () => ({ status: 200, body: 'mock' }),
+  WEBHOOK_TRIGGER: (_n, sample) => ({ body: sample || {}, headers: {}, method: 'POST' }),
+  FORM_TRIGGER: (_n, sample) => ({ formData: sample || { field1: 'value1' } }),
+
+  // Transform / Code nodes
+  TRANSFORM: (_n, sample) => sample ? { transformed: sample } : { transformed: {} },
+  CODE: (_n, sample) => ({ result: sample || 'mock code output' }),
+  FUNCTION: (_n, sample) => ({ result: sample || 'mock function output' }),
+
+  // Condition / Router
+  CONDITION: (_n, sample) => ({ conditionMet: true, branch: 'true', data: sample || {} }),
+  IF: (_n, sample) => ({ conditionMet: true, branch: 'true', data: sample || {} }),
+  SWITCH: () => ({ matchedCase: 'case_0', data: {} }),
+  ROUTER: () => ({ route: 'default', data: {} }),
+
+  // LLM / AI nodes
+  LLM: () => ({ text: 'mock AI response' }),
+  OPENAI: () => ({ text: 'mock AI response', model: 'gpt-4', usage: { tokens: 42 } }),
+  ANTHROPIC: () => ({ text: 'mock AI response', model: 'claude', usage: { tokens: 42 } }),
+  AI_AGENT: () => ({ text: 'mock AI agent response', toolCalls: [] }),
+
+  // Communication
+  TELEGRAM: () => ({ messageId: 12345, chat: { id: 1 }, ok: true }),
+  TELEGRAM_TRIGGER: () => ({ message: { text: 'mock message', from: { id: 1, username: 'test' } } }),
+  GMAIL: () => ({ id: 'msg-001', threadId: 'thread-001', labelIds: ['SENT'] }),
+  GMAIL_TRIGGER: () => ({ id: 'msg-001', subject: 'Mock email', from: 'test@example.com' }),
+  SLACK: () => ({ ok: true, channel: 'C01', ts: '1234567890.123456' }),
+  SLACK_TRIGGER: () => ({ text: 'mock slack message', user: 'U01', channel: 'C01' }),
+  DISCORD: () => ({ id: '123456', content: 'mock message sent' }),
+  EMAIL: () => ({ messageId: '<mock@email.com>', accepted: ['test@example.com'] }),
+  WHATSAPP: () => ({ messageId: 'wamid.mock', status: 'sent' }),
+  TEAMS: () => ({ id: 'msg-mock', createdDateTime: new Date().toISOString() }),
+
+  // Storage / Database
+  GOOGLE_SHEETS: () => ({ updatedRange: 'Sheet1!A1:B2', updatedRows: 1 }),
+  GOOGLE_SHEETS_TRIGGER: () => ({ row: { A: 'value1', B: 'value2' } }),
+  GOOGLE_DRIVE: () => ({ id: 'file-001', name: 'mock-file.txt', mimeType: 'text/plain' }),
+  GOOGLE_DRIVE_TRIGGER: () => ({ fileId: 'file-001', name: 'mock-file.txt', change: 'created' }),
+  DATABASE: () => ({ rows: [{ id: 1, name: 'mock' }], rowCount: 1 }),
+  REDIS: () => ({ value: 'mock-value', key: 'mock-key' }),
+  MONGODB: () => ({ insertedId: 'mock-id', acknowledged: true }),
+  AWS_S3: () => ({ key: 'mock-key', bucket: 'mock-bucket', etag: 'mock-etag' }),
+
+  // CRM
+  HUBSPOT: () => ({ id: '1', properties: { email: 'mock@example.com' } }),
+  PIPEDRIVE: () => ({ id: 1, name: 'Mock Deal', status: 'open' }),
+  SALESFORCE: () => ({ id: '001', success: true }),
+  MONDAY: () => ({ id: '123', name: 'Mock item' }),
+
+  // E-commerce
+  STRIPE: () => ({ id: 'ch_mock', amount: 1000, currency: 'usd', status: 'succeeded' }),
+  STRIPE_TRIGGER: () => ({ type: 'payment_intent.succeeded', data: { object: { id: 'pi_mock' } } }),
+  SHOPIFY: () => ({ id: 123, title: 'Mock Product' }),
+  GUMROAD: () => ({ id: 'sale-mock', product_name: 'Mock Product', price: 999 }),
+
+  // Project management
+  JIRA: () => ({ id: '10001', key: 'MOCK-1', summary: 'Mock issue' }),
+  JIRA_TRIGGER: () => ({ issue: { key: 'MOCK-1', fields: { summary: 'Mock issue' } } }),
+  TRELLO: () => ({ id: 'card-mock', name: 'Mock card', idList: 'list-mock' }),
+  ASANA: () => ({ gid: '12345', name: 'Mock task', completed: false }),
+  GITHUB: () => ({ id: 1, title: 'Mock issue', state: 'open' }),
+  GITHUB_TRIGGER: () => ({ action: 'opened', repository: { full_name: 'mock/repo' } }),
+  GITLAB: () => ({ id: 1, title: 'Mock MR', state: 'opened' }),
+
+  // Marketing
+  MAILCHIMP: () => ({ id: 'member-mock', email_address: 'mock@example.com', status: 'subscribed' }),
+  SENDGRID: () => ({ statusCode: 202, body: '' }),
+
+  // Social
+  TWITTER: () => ({ id: 'tweet-mock', text: 'Mock tweet' }),
+  FACEBOOK: () => ({ id: 'post-mock', message: 'Mock post' }),
+  INSTAGRAM: () => ({ id: 'media-mock', caption: 'Mock caption' }),
+  PINTEREST: () => ({ id: 'pin-mock', title: 'Mock pin' }),
+
+  // Scheduling
+  SCHEDULE: () => ({ triggered: true, scheduledTime: new Date().toISOString() }),
+  CRON: () => ({ triggered: true, cronExpression: '0 * * * *' }),
+  WAIT: () => ({ resumed: true, waitedMs: 1000 }),
+  DELAY: () => ({ resumed: true, delayMs: 1000 }),
+
+  // Utility
+  SET: (_n, sample) => sample || { key: 'value' },
+  MERGE: () => ({ merged: true, items: [] }),
+  SPLIT: () => ({ items: [[], []] }),
+  FILTER: (_n, sample) => ({ filtered: sample || [], kept: 1, removed: 0 }),
+  LOOP: () => ({ iteration: 0, items: [] }),
+  ERROR_TRIGGER: () => ({ error: { message: 'mock error', node: 'mock-node' } }),
+  NO_OP: () => ({}),
+  NOTE: () => ({}),
+
+  // Finance
+  PLAID: () => ({ accounts: [{ id: 'acc-mock', name: 'Mock Account' }] }),
+  WISE: () => ({ id: 'transfer-mock', status: 'completed' }),
+  CHARGEBEE: () => ({ subscription: { id: 'sub-mock', status: 'active' } }),
+
+  // Forms
+  TYPEFORM: () => ({ response_id: 'resp-mock', answers: [] }),
+  JOTFORM: () => ({ submissionID: 'sub-mock', answers: {} }),
+
+  // Connector-based (generic)
+  CONNECTOR_TRIGGER: () => ({ event: 'mock_event', data: {} }),
+  CONNECTOR_ACTION: () => ({ success: true, data: {} }),
+
+  // Calendar
+  GOOGLE_CALENDAR: () => ({ id: 'event-mock', summary: 'Mock Event' }),
+  GOOGLE_CALENDAR_TRIGGER: () => ({ id: 'event-mock', summary: 'Mock Event', start: {} }),
+
+  // Support
+  FRESHDESK: () => ({ id: 1, subject: 'Mock ticket', status: 2 }),
+
+  // Productivity
+  CLOCKIFY: () => ({ id: 'entry-mock', description: 'Mock time entry' }),
+  TOGGL: () => ({ id: 12345, description: 'Mock time entry' }),
+};
+
+/**
+ * DryRunService
+ *
+ * Traces workflow execution without calling external APIs.
+ * For each node it validates configuration, checks credential
+ * availability, and returns mock output based on the node type.
+ */
+@Injectable()
+export class DryRunService {
+  private readonly logger = new Logger(DryRunService.name);
+
+  constructor(
+    private readonly platformService: PlatformService,
+  ) {}
+
+  /**
+   * Run a dry-run of the given workflow.
+   *
+   * @param workflowId  The ID of the persisted workflow
+   * @param sampleInput Optional sample input fed into the first node
+   */
+  async dryRun(workflowId: string, sampleInput?: Record<string, any>): Promise<DryRunResult> {
+    this.logger.log(`Starting dry-run for workflow ${workflowId}`);
+
+    // 1. Load workflow definition
+    const workflow = await this.loadWorkflow(workflowId);
+    const canvas = workflow.workflow?.canvas || workflow.canvas;
+
+    if (!canvas || !canvas.nodes || canvas.nodes.length === 0) {
+      return {
+        workflowId,
+        steps: [],
+        errors: ['Workflow has no nodes defined'],
+        warnings: [],
+        totalNodes: 0,
+        executionOrder: [],
+      };
+    }
+
+    const nodes: INode[] = canvas.nodes;
+    const edges: IEdge[] = canvas.edges || [];
+
+    // 2. Determine execution order (topological sort via BFS from trigger/start node)
+    const executionOrder = this.getExecutionOrder(nodes, edges);
+
+    // 3. Gather credential info for the project
+    const projectId = workflow.project_id;
+    const credentialMap = await this.getCredentialMap(projectId);
+
+    // 4. Walk each node
+    const steps: DryRunStepResult[] = [];
+    const globalErrors: string[] = [];
+    const globalWarnings: string[] = [];
+
+    let previousOutput: any = sampleInput || {};
+
+    for (const nodeId of executionOrder) {
+      const node = nodes.find(n => n.id === nodeId);
+      if (!node) {
+        globalWarnings.push(`Node ${nodeId} referenced in edges but not found in nodes array`);
+        continue;
+      }
+
+      const step = this.evaluateNode(node, previousOutput, credentialMap);
+      steps.push(step);
+
+      if (step.errors && step.errors.length > 0) {
+        globalErrors.push(...step.errors.map(e => `[${step.nodeName || step.nodeId}] ${e}`));
+      }
+      if (step.warnings && step.warnings.length > 0) {
+        globalWarnings.push(...step.warnings.map(w => `[${step.nodeName || step.nodeId}] ${w}`));
+      }
+
+      // Feed mock output forward
+      previousOutput = step.mockOutput;
+    }
+
+    this.logger.log(
+      `Dry-run complete for workflow ${workflowId}: ${steps.length} steps, ${globalErrors.length} errors, ${globalWarnings.length} warnings`,
+    );
+
+    return {
+      workflowId,
+      steps,
+      errors: globalErrors,
+      warnings: globalWarnings,
+      totalNodes: nodes.length,
+      executionOrder,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Private helpers
+  // ------------------------------------------------------------------
+
+  private async loadWorkflow(workflowId: string): Promise<any> {
+    const result = await this.platformService.query(
+      'SELECT * FROM workflows WHERE id = $1',
+      [workflowId],
+    );
+
+    if (!result.rows || result.rows.length === 0) {
+      throw new NotFoundException(`Workflow ${workflowId} not found`);
+    }
+
+    return result.rows[0];
+  }
+
+  /**
+   * Build a map of connector_type -> boolean indicating whether credentials
+   * are available for this project.
+   */
+  private async getCredentialMap(projectId?: string): Promise<Record<string, boolean>> {
+    if (!projectId) return {};
+
+    try {
+      const result = await this.platformService.query(
+        `SELECT connector_type, is_active FROM connector_configs WHERE project_id = $1`,
+        [projectId],
+      );
+      const map: Record<string, boolean> = {};
+      for (const row of result.rows || []) {
+        map[row.connector_type] = row.is_active !== false;
+      }
+      return map;
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Topological BFS from root node(s) following edge direction.
+   */
+  private getExecutionOrder(nodes: INode[], edges: IEdge[]): string[] {
+    const adjacency: Record<string, string[]> = {};
+    const inDegree: Record<string, number> = {};
+
+    for (const node of nodes) {
+      adjacency[node.id] = [];
+      inDegree[node.id] = 0;
+    }
+
+    for (const edge of edges) {
+      if (adjacency[edge.source]) {
+        adjacency[edge.source].push(edge.target);
+      }
+      if (inDegree[edge.target] !== undefined) {
+        inDegree[edge.target]++;
+      }
+    }
+
+    // Start from nodes with 0 in-degree (triggers / start nodes)
+    const queue: string[] = [];
+    for (const node of nodes) {
+      if (inDegree[node.id] === 0) {
+        queue.push(node.id);
+      }
+    }
+
+    const order: string[] = [];
+    const visited = new Set<string>();
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      order.push(current);
+
+      for (const next of adjacency[current] || []) {
+        inDegree[next]--;
+        if (inDegree[next] <= 0 && !visited.has(next)) {
+          queue.push(next);
+        }
+      }
+    }
+
+    // Include any disconnected nodes not yet visited
+    for (const node of nodes) {
+      if (!visited.has(node.id)) {
+        order.push(node.id);
+      }
+    }
+
+    return order;
+  }
+
+  /**
+   * Evaluate a single node: validate config, check creds, produce mock output.
+   */
+  private evaluateNode(
+    node: INode,
+    sampleInput: any,
+    credentialMap: Record<string, boolean>,
+  ): DryRunStepResult {
+    const nodeType = node.type || 'UNKNOWN';
+    const nodeName = node.data?.label || node.data?.name || nodeType;
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    // --- Config validation ---
+    const configValid = this.validateNodeConfig(node, errors, warnings);
+
+    // --- Credential check ---
+    const credentialsAvailable = this.checkCredentials(node, credentialMap, warnings);
+
+    // --- Determine what would happen ---
+    const wouldExecute = this.describeExecution(node);
+
+    // --- Generate mock output ---
+    const mockOutput = this.generateMockOutput(node, sampleInput);
+
+    return {
+      nodeId: node.id,
+      nodeName,
+      nodeType,
+      configValid,
+      credentialsAvailable,
+      wouldExecute,
+      mockOutput,
+      errors: errors.length > 0 ? errors : undefined,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+  }
+
+  private validateNodeConfig(node: INode, errors: string[], warnings: string[]): boolean {
+    const data = node.data || {};
+    const nodeType = node.type || '';
+    let valid = true;
+
+    // Check for completely empty configuration
+    const hasAnyConfig = Object.keys(data).some(
+      k => !['label', 'name', 'icon', 'color', 'description'].includes(k) && data[k] != null,
+    );
+
+    if (!hasAnyConfig) {
+      warnings.push('Node has no configuration set');
+    }
+
+    // Type-specific checks
+    if (nodeType.includes('HTTP') && !data.url) {
+      errors.push('HTTP node missing required "url" field');
+      valid = false;
+    }
+
+    if (nodeType.includes('EMAIL') || nodeType.includes('GMAIL')) {
+      if (data.action === 'send_email' || data.actionId === 'send_email') {
+        if (!data.to && !data.config?.to) {
+          warnings.push('Email node has no "to" address configured');
+        }
+      }
+    }
+
+    if (nodeType.includes('TELEGRAM')) {
+      if (
+        (data.action === 'send_message' || data.actionId === 'send_message') &&
+        !data.chatId &&
+        !data.config?.chatId
+      ) {
+        warnings.push('Telegram node has no "chatId" configured');
+      }
+    }
+
+    if (nodeType === 'CONDITION' || nodeType === 'IF') {
+      if (!data.conditions && !data.config?.conditions) {
+        warnings.push('Condition node has no conditions defined');
+      }
+    }
+
+    if (nodeType === 'CODE' || nodeType === 'FUNCTION') {
+      if (!data.code && !data.config?.code) {
+        errors.push('Code node has no code defined');
+        valid = false;
+      }
+    }
+
+    if (nodeType === 'SCHEDULE' || nodeType === 'CRON') {
+      if (!data.cronExpression && !data.config?.cronExpression && !data.interval && !data.config?.interval) {
+        warnings.push('Schedule node has no cron expression or interval set');
+      }
+    }
+
+    return valid;
+  }
+
+  private checkCredentials(
+    node: INode,
+    credentialMap: Record<string, boolean>,
+    warnings: string[],
+  ): boolean {
+    const nodeType = node.type || '';
+    const connectorType = node.data?.connectorType || node.data?.connector_type;
+
+    // Utility / logic nodes don't need credentials
+    const noCredNeeded = [
+      'CONDITION', 'IF', 'SWITCH', 'ROUTER', 'SET', 'MERGE', 'SPLIT',
+      'FILTER', 'LOOP', 'CODE', 'FUNCTION', 'TRANSFORM', 'WAIT', 'DELAY',
+      'NOTE', 'NO_OP', 'ERROR_TRIGGER', 'SCHEDULE', 'CRON',
+      'WEBHOOK_TRIGGER', 'FORM_TRIGGER',
+    ];
+
+    if (noCredNeeded.some(t => nodeType.includes(t))) {
+      return true;
+    }
+
+    // If the node references a specific connector config id, assume it's fine
+    if (node.data?.connectorConfigId || node.data?.connector_config_id) {
+      return true;
+    }
+
+    // Try to match by connector type
+    const typeKey = connectorType || nodeType.replace(/_TRIGGER$/, '').replace(/_ACTION$/, '').toLowerCase();
+
+    if (typeKey && credentialMap[typeKey] !== undefined) {
+      if (!credentialMap[typeKey]) {
+        warnings.push(`Credentials for "${typeKey}" exist but are inactive`);
+        return false;
+      }
+      return true;
+    }
+
+    // Could not determine — warn
+    if (typeKey && !noCredNeeded.some(t => nodeType.includes(t))) {
+      warnings.push(`Could not verify credentials for connector "${typeKey}"`);
+    }
+
+    return false;
+  }
+
+  private describeExecution(node: INode): string {
+    const nodeType = node.type || 'UNKNOWN';
+    const action = node.data?.action || node.data?.actionId || '';
+    const connectorType = node.data?.connectorType || '';
+
+    if (nodeType.includes('TRIGGER')) {
+      return `Would listen for incoming ${connectorType || nodeType.replace('_TRIGGER', '')} events`;
+    }
+
+    if (nodeType === 'HTTP_REQUEST') {
+      const method = node.data?.method || node.data?.config?.method || 'GET';
+      const url = node.data?.url || node.data?.config?.url || '<not set>';
+      return `Would make ${method} request to ${url}`;
+    }
+
+    if (nodeType === 'CODE' || nodeType === 'FUNCTION') {
+      return 'Would execute custom code/function';
+    }
+
+    if (nodeType === 'CONDITION' || nodeType === 'IF') {
+      return 'Would evaluate condition and branch';
+    }
+
+    if (nodeType === 'SWITCH' || nodeType === 'ROUTER') {
+      return 'Would route to matching case';
+    }
+
+    if (nodeType === 'TRANSFORM') {
+      return 'Would transform data';
+    }
+
+    if (nodeType === 'WAIT' || nodeType === 'DELAY') {
+      return 'Would pause execution';
+    }
+
+    if (nodeType === 'SCHEDULE' || nodeType === 'CRON') {
+      return 'Would run on schedule';
+    }
+
+    if (action) {
+      return `Would execute "${action}" on ${connectorType || nodeType}`;
+    }
+
+    return `Would execute ${connectorType || nodeType} node`;
+  }
+
+  private generateMockOutput(node: INode, sampleInput: any): any {
+    const nodeType = node.type || 'UNKNOWN';
+
+    // Try exact match first
+    const generator = MOCK_OUTPUTS[nodeType];
+    if (generator) {
+      return generator(node, sampleInput);
+    }
+
+    // Try prefix match (e.g. GOOGLE_SHEETS_TRIGGER matches GOOGLE_SHEETS)
+    for (const [key, gen] of Object.entries(MOCK_OUTPUTS)) {
+      if (nodeType.startsWith(key)) {
+        return gen(node, sampleInput);
+      }
+    }
+
+    // Fallback: generic mock
+    return { success: true, data: sampleInput || {} };
+  }
+}

--- a/backend/src/modules/fluxturn/workflow/services/workflow-execution.engine.ts
+++ b/backend/src/modules/fluxturn/workflow/services/workflow-execution.engine.ts
@@ -83,6 +83,7 @@ export class WorkflowExecutionEngine {
       destinationNodeId?: string;
       mode?: 'manual' | 'production';
       executionId?: string;
+      dryRun?: boolean;
     } = {}
   ): Promise<any> {
     this.logger.log(`Starting workflow execution with ${workflow.nodes.length} nodes`);
@@ -129,7 +130,8 @@ export class WorkflowExecutionEngine {
           metadata: {
             startedAt: new Date(),
             executionId: options.executionId,
-            mode: options.mode || 'manual'
+            mode: options.mode || 'manual',
+            dryRun: options.dryRun || false
           }
         }
       };

--- a/backend/src/modules/fluxturn/workflow/services/workflow-execution.engine.ts
+++ b/backend/src/modules/fluxturn/workflow/services/workflow-execution.engine.ts
@@ -1,7 +1,8 @@
-import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
+import { Injectable, Logger, Inject, forwardRef, Optional } from '@nestjs/common';
 import { NodeExecutorService } from './node-executor.service';
 import { ControlFlowService } from './control-flow.service';
 import { EventsGateway } from '../../../../events/events.gateway';
+import { SecretsService } from '../../../secrets/secrets.service';
 
 /**
  * Interfaces for workflow execution
@@ -69,7 +70,8 @@ export class WorkflowExecutionEngine {
     private readonly nodeExecutor: NodeExecutorService,
     private readonly controlFlowService: ControlFlowService,
     @Inject(forwardRef(() => EventsGateway))
-    private readonly eventsGateway: EventsGateway
+    private readonly eventsGateway: EventsGateway,
+    @Optional() private readonly secretsService?: SecretsService
   ) {}
 
   /**
@@ -163,7 +165,8 @@ export class WorkflowExecutionEngine {
     while (nodeExecutionStack.length > 0) {
       // Pop next node from stack
       const executionStackItem = nodeExecutionStack.shift()!;
-      const { node, data, source } = executionStackItem;
+      let { node } = executionStackItem;
+      const { data, source } = executionStackItem;
 
       this.logger.log(
         `[${executedNodesCount + 1}/${totalNodes}] Executing: ${node.data?.label || node.id} (${node.type})`
@@ -207,6 +210,20 @@ export class WorkflowExecutionEngine {
           },
           $env: process.env
         };
+
+        // Resolve {{secrets.NAME}} references in node config before execution
+        if (this.secretsService && node.data) {
+          try {
+            node = {
+              ...node,
+              data: await this.secretsService.resolveSecretsInObject(node.data),
+            };
+          } catch (secretsError: any) {
+            this.logger.warn(
+              `Failed to resolve secrets for node ${node.data?.label || node.id}: ${secretsError.message}`,
+            );
+          }
+        }
 
         // Execute the node
         let nodeOutput: any[][];

--- a/backend/src/modules/fluxturn/workflow/workflow.controller.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.controller.ts
@@ -21,6 +21,8 @@ import { WorkflowService } from './workflow.service';
 import { TriggerType } from './interfaces/trigger.interface';
 import { JwtOrApiKeyAuthGuard } from '../../auth/guards/jwt-or-api-key-auth.guard';
 import { ToolRegistryService } from './services/tool-registry.service';
+import { DryRunService } from './services/dry-run.service';
+import { DryRunDto } from './dto/dry-run.dto';
 import {
   CreateWorkflowDto,
   ExecuteWorkflowDto,
@@ -57,6 +59,7 @@ export class WorkflowController {
   constructor(
     private readonly workflowService: WorkflowService,
     private readonly toolRegistryService: ToolRegistryService,
+    private readonly dryRunService: DryRunService,
   ) {}
 
   @Post('create')
@@ -140,6 +143,51 @@ export class WorkflowController {
       body.nodeId,
       body.testData || {}
     );
+  }
+
+  @Post(':id/dry-run')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Dry-run a workflow without executing real actions',
+    description:
+      'Traces the execution path, validates node configuration, checks credential availability, and returns mock output for every node without calling any external APIs.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Dry-run completed successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        workflowId: { type: 'string' },
+        steps: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              nodeId: { type: 'string' },
+              nodeName: { type: 'string' },
+              nodeType: { type: 'string' },
+              configValid: { type: 'boolean' },
+              credentialsAvailable: { type: 'boolean' },
+              wouldExecute: { type: 'string' },
+              mockOutput: { type: 'object' },
+            },
+          },
+        },
+        errors: { type: 'array', items: { type: 'string' } },
+        warnings: { type: 'array', items: { type: 'string' } },
+        totalNodes: { type: 'number' },
+        executionOrder: { type: 'array', items: { type: 'string' } },
+      },
+    },
+  })
+  @ApiBody({ type: DryRunDto })
+  async dryRunWorkflow(
+    @Param('id') workflowId: string,
+    @Body(ValidationPipe) dto: DryRunDto,
+    @Request() req: any
+  ) {
+    return this.dryRunService.dryRun(workflowId, dto.sampleInput);
   }
 
   @Get('list')

--- a/backend/src/modules/fluxturn/workflow/workflow.module.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.module.ts
@@ -82,6 +82,7 @@ import { WorkflowAgentsService } from './services/workflow-agents.service';
 import { OrchestratedGeneratorService } from './services/orchestrated-generator.service';
 import { DryRunService } from './services/dry-run.service';
 import { AuditModule } from '../audit/audit.module';
+import { SecretsModule } from '../../secrets/secrets.module';
 // import { TemplateSeederService } from './services/template-seeder.service';
 
 @Module({
@@ -95,6 +96,7 @@ import { AuditModule } from '../audit/audit.module';
     EventsModule,
     NodesModule,
     AuditModule,
+    SecretsModule,
   ],
   controllers: [
     TemplateController, // Must be before WorkflowController to avoid route conflicts

--- a/backend/src/modules/fluxturn/workflow/workflow.module.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.module.ts
@@ -80,6 +80,7 @@ import { AvailableNodesSeederService } from './services/available-nodes-seeder.s
 import { NodesModule } from './nodes/nodes.module';
 import { WorkflowAgentsService } from './services/workflow-agents.service';
 import { OrchestratedGeneratorService } from './services/orchestrated-generator.service';
+import { DryRunService } from './services/dry-run.service';
 import { AuditModule } from '../audit/audit.module';
 // import { TemplateSeederService } from './services/template-seeder.service';
 
@@ -132,6 +133,7 @@ import { AuditModule } from '../audit/audit.module';
   ],
   providers: [
     WorkflowService,
+    DryRunService,
     TemplateService,
     WorkflowExecutionEngine,
     NodeExecutorService,

--- a/backend/src/modules/fluxturn/workflow/workflow.module.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.module.ts
@@ -80,6 +80,7 @@ import { AvailableNodesSeederService } from './services/available-nodes-seeder.s
 import { NodesModule } from './nodes/nodes.module';
 import { WorkflowAgentsService } from './services/workflow-agents.service';
 import { OrchestratedGeneratorService } from './services/orchestrated-generator.service';
+import { AuditModule } from '../audit/audit.module';
 // import { TemplateSeederService } from './services/template-seeder.service';
 
 @Module({
@@ -92,6 +93,7 @@ import { OrchestratedGeneratorService } from './services/orchestrated-generator.
     forwardRef(() => ConnectorsModule),
     EventsModule,
     NodesModule,
+    AuditModule,
   ],
   controllers: [
     TemplateController, // Must be before WorkflowController to avoid route conflicts

--- a/backend/src/modules/fluxturn/workflow/workflow.service.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.service.ts
@@ -11,6 +11,7 @@ import { TriggerManagerService } from './services/trigger-manager.service';
 import { TriggerType } from './interfaces/trigger.interface';
 import { AIWorkflowGeneratorService } from './services/ai-workflow-generator.service';
 import { IntentDetectionService } from './services/intent-detection.service';
+import { AuditService } from '../audit/audit.service';
 // compareConnectorFields removed - seeding now done via npm run seed:connector
 
 @Injectable()
@@ -28,6 +29,7 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
     private triggerManager: TriggerManagerService,
     private aiWorkflowGenerator: AIWorkflowGeneratorService,
     private intentDetection: IntentDetectionService,
+    private auditService: AuditService,
   ) {}
 
   async onModuleInit() {
@@ -304,8 +306,27 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         }
       }
 
+      const created = result.rows[0];
+
+      // Audit log
+      this.auditService.log(
+        'workflow.created',
+        params.created_by,
+        'workflow',
+        created.id,
+        {
+          organizationId: params.organization_id,
+          projectId: params.project_id,
+          details: {
+            name: created.name,
+            isAiGenerated,
+            templateId: params.template_id || null,
+          },
+        },
+      ).catch(err => this.logger.warn('Audit log failed:', err.message));
+
       return {
-        ...result.rows[0],
+        ...created,
         confidence,
         generationStrategy: params.prompt ? 'hybrid' : 'manual'
       };
@@ -425,6 +446,21 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         ]);
 
         this.logger.log(`Workflow execution completed: ${executionId}`);
+
+        // Audit log
+        if (workflowRow.user_id || workflowRow.created_by) {
+          this.auditService.log(
+            'workflow.executed',
+            workflowRow.user_id || workflowRow.created_by,
+            'workflow',
+            params.workflow_id,
+            {
+              organizationId: workflowRow.organization_id,
+              projectId: workflowRow.project_id,
+              details: { executionId, status: 'completed' },
+            },
+          ).catch(err => this.logger.warn('Audit log failed:', err.message));
+        }
 
         return {
           ...executionResult.rows[0],
@@ -2181,6 +2217,23 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         };
       }
 
+      // Audit log
+      if (params.updated_by) {
+        this.auditService.log(
+          'workflow.updated',
+          params.updated_by,
+          'workflow',
+          workflowId,
+          {
+            organizationId: params.organization_id,
+            projectId: params.project_id,
+            details: {
+              updatedFields: Object.keys(params).filter(k => params[k] !== undefined && k !== 'updated_by' && k !== 'organization_id' && k !== 'project_id'),
+            },
+          },
+        ).catch(err => this.logger.warn('Audit log failed:', err.message));
+      }
+
       // Return workflow data with trigger results
       return {
         ...updatedWorkflow,
@@ -2236,9 +2289,25 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         throw new NotFoundException('Workflow not found');
       }
 
+      // Audit log
+      const deletedWorkflow = result.rows[0];
+      if (workflow?.user_id || workflow?.created_by) {
+        this.auditService.log(
+          'workflow.deleted',
+          workflow.user_id || workflow.created_by,
+          'workflow',
+          workflowId,
+          {
+            organizationId: organizationId,
+            projectId: projectId,
+            details: { name: deletedWorkflow.name },
+          },
+        ).catch(err => this.logger.warn('Audit log failed:', err.message));
+      }
+
       return {
         message: 'Workflow deleted successfully',
-        workflow: result.rows[0]
+        workflow: deletedWorkflow
       };
     } catch (error) {
       this.logger.error('Failed to delete workflow:', error);

--- a/backend/src/modules/secrets/index.ts
+++ b/backend/src/modules/secrets/index.ts
@@ -1,0 +1,2 @@
+export { SecretsModule } from './secrets.module';
+export { SecretsService } from './secrets.service';

--- a/backend/src/modules/secrets/providers/env.provider.ts
+++ b/backend/src/modules/secrets/providers/env.provider.ts
@@ -1,0 +1,27 @@
+import { Logger } from '@nestjs/common';
+import { ISecretsProvider } from './secrets-provider.interface';
+
+/**
+ * Environment variable secrets provider.
+ * Read-only: getSecret('STRIPE_KEY') returns process.env.STRIPE_KEY.
+ */
+export class EnvSecretsProvider implements ISecretsProvider {
+  private readonly logger = new Logger(EnvSecretsProvider.name);
+
+  async getSecret(name: string): Promise<string | null> {
+    return process.env[name] || null;
+  }
+
+  async listSecrets(): Promise<string[]> {
+    // Return all environment variable names
+    return Object.keys(process.env).sort();
+  }
+
+  async setSecret(_name: string, _value: string): Promise<void> {
+    throw new Error('EnvSecretsProvider is read-only. Cannot set secrets via environment variables at runtime.');
+  }
+
+  async deleteSecret(_name: string): Promise<void> {
+    throw new Error('EnvSecretsProvider is read-only. Cannot delete secrets via environment variables at runtime.');
+  }
+}

--- a/backend/src/modules/secrets/providers/index.ts
+++ b/backend/src/modules/secrets/providers/index.ts
@@ -1,0 +1,4 @@
+export { ISecretsProvider } from './secrets-provider.interface';
+export { LocalSecretsProvider } from './local.provider';
+export { EnvSecretsProvider } from './env.provider';
+export { VaultSecretsProvider } from './vault.provider';

--- a/backend/src/modules/secrets/providers/local.provider.ts
+++ b/backend/src/modules/secrets/providers/local.provider.ts
@@ -1,0 +1,100 @@
+import { Logger } from '@nestjs/common';
+import * as crypto from 'crypto';
+import { ISecretsProvider } from './secrets-provider.interface';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 16;
+const TAG_LENGTH = 16;
+
+/**
+ * Local secrets provider - stores AES-256-GCM encrypted secrets in PostgreSQL.
+ * Table: secrets (id, name UNIQUE, encrypted_value, iv, tag, created_at, updated_at)
+ */
+export class LocalSecretsProvider implements ISecretsProvider {
+  private readonly logger = new Logger(LocalSecretsProvider.name);
+  private readonly encryptionKey: Buffer;
+
+  constructor(
+    private readonly platformService: any,
+    encryptionKey: string,
+  ) {
+    if (!encryptionKey || encryptionKey.length < 32) {
+      throw new Error(
+        'SECRETS_ENCRYPTION_KEY must be at least 32 characters for AES-256-GCM',
+      );
+    }
+    // Derive a 32-byte key from the provided key
+    this.encryptionKey = crypto
+      .createHash('sha256')
+      .update(encryptionKey)
+      .digest();
+  }
+
+  private encrypt(plaintext: string): { encrypted: string; iv: string; tag: string } {
+    const iv = crypto.randomBytes(IV_LENGTH);
+    const cipher = crypto.createCipheriv(ALGORITHM, this.encryptionKey, iv);
+
+    let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+    const tag = cipher.getAuthTag();
+
+    return {
+      encrypted,
+      iv: iv.toString('hex'),
+      tag: tag.toString('hex'),
+    };
+  }
+
+  private decrypt(encrypted: string, ivHex: string, tagHex: string): string {
+    const iv = Buffer.from(ivHex, 'hex');
+    const tag = Buffer.from(tagHex, 'hex');
+    const decipher = crypto.createDecipheriv(ALGORITHM, this.encryptionKey, iv);
+    decipher.setAuthTag(tag);
+
+    let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+    return decrypted;
+  }
+
+  async getSecret(name: string): Promise<string | null> {
+    try {
+      const result = await this.platformService.query(
+        'SELECT encrypted_value, iv, tag FROM secrets WHERE name = $1',
+        [name],
+      );
+      if (result.rows.length === 0) return null;
+
+      const row = result.rows[0];
+      return this.decrypt(row.encrypted_value, row.iv, row.tag);
+    } catch (error) {
+      this.logger.error(`Failed to get secret "${name}": ${error.message}`);
+      return null;
+    }
+  }
+
+  async listSecrets(): Promise<string[]> {
+    const result = await this.platformService.query(
+      'SELECT name FROM secrets ORDER BY name ASC',
+    );
+    return result.rows.map((row: any) => row.name);
+  }
+
+  async setSecret(name: string, value: string): Promise<void> {
+    const { encrypted, iv, tag } = this.encrypt(value);
+    const now = new Date();
+
+    await this.platformService.query(
+      `INSERT INTO secrets (id, name, encrypted_value, iv, tag, created_at, updated_at)
+       VALUES (uuid_generate_v4(), $1, $2, $3, $4, $5, $6)
+       ON CONFLICT (name) DO UPDATE SET encrypted_value = $2, iv = $3, tag = $4, updated_at = $6`,
+      [name, encrypted, iv, tag, now, now],
+    );
+  }
+
+  async deleteSecret(name: string): Promise<void> {
+    await this.platformService.query(
+      'DELETE FROM secrets WHERE name = $1',
+      [name],
+    );
+  }
+}

--- a/backend/src/modules/secrets/providers/secrets-provider.interface.ts
+++ b/backend/src/modules/secrets/providers/secrets-provider.interface.ts
@@ -1,0 +1,17 @@
+/**
+ * Interface for secrets provider implementations.
+ * Each provider (local, env, vault) must implement this contract.
+ */
+export interface ISecretsProvider {
+  /** Fetch a secret value by name */
+  getSecret(name: string): Promise<string | null>;
+
+  /** List available secret names (not values) */
+  listSecrets(): Promise<string[]>;
+
+  /** Store a secret. Not all providers support this (e.g., env is read-only). */
+  setSecret(name: string, value: string): Promise<void>;
+
+  /** Delete a secret. Not all providers support this (e.g., env is read-only). */
+  deleteSecret(name: string): Promise<void>;
+}

--- a/backend/src/modules/secrets/providers/vault.provider.ts
+++ b/backend/src/modules/secrets/providers/vault.provider.ts
@@ -1,0 +1,82 @@
+import { Logger } from '@nestjs/common';
+import axios from 'axios';
+import { ISecretsProvider } from './secrets-provider.interface';
+
+/**
+ * HashiCorp Vault secrets provider.
+ * Communicates with Vault via HTTP API using a static token.
+ * Reads from the KV v2 secrets engine at /v1/secret/data/{name}.
+ */
+export class VaultSecretsProvider implements ISecretsProvider {
+  private readonly logger = new Logger(VaultSecretsProvider.name);
+  private readonly vaultAddr: string;
+  private readonly vaultToken: string;
+
+  constructor(vaultAddr: string, vaultToken: string) {
+    if (!vaultAddr) {
+      throw new Error('VAULT_ADDR is required for vault secrets provider');
+    }
+    if (!vaultToken) {
+      throw new Error('VAULT_TOKEN is required for vault secrets provider');
+    }
+    // Remove trailing slash
+    this.vaultAddr = vaultAddr.replace(/\/+$/, '');
+    this.vaultToken = vaultToken;
+  }
+
+  private get headers() {
+    return { 'X-Vault-Token': this.vaultToken };
+  }
+
+  async getSecret(name: string): Promise<string | null> {
+    try {
+      const response = await axios.get(
+        `${this.vaultAddr}/v1/secret/data/${name}`,
+        { headers: this.headers },
+      );
+      // KV v2 returns data nested under data.data
+      const data = response.data?.data?.data;
+      if (!data) return null;
+      // Return the "value" key, or the first key's value
+      return data.value ?? Object.values(data)[0] ?? null;
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        return null;
+      }
+      this.logger.error(`Failed to get secret "${name}" from Vault: ${error.message}`);
+      return null;
+    }
+  }
+
+  async listSecrets(): Promise<string[]> {
+    try {
+      const response = await axios.request({
+        method: 'LIST',
+        url: `${this.vaultAddr}/v1/secret/metadata/`,
+        headers: this.headers,
+      });
+      return response.data?.data?.keys || [];
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        return [];
+      }
+      this.logger.error(`Failed to list secrets from Vault: ${error.message}`);
+      return [];
+    }
+  }
+
+  async setSecret(name: string, value: string): Promise<void> {
+    await axios.post(
+      `${this.vaultAddr}/v1/secret/data/${name}`,
+      { data: { value } },
+      { headers: this.headers },
+    );
+  }
+
+  async deleteSecret(name: string): Promise<void> {
+    await axios.delete(
+      `${this.vaultAddr}/v1/secret/metadata/${name}`,
+      { headers: this.headers },
+    );
+  }
+}

--- a/backend/src/modules/secrets/secrets.controller.ts
+++ b/backend/src/modules/secrets/secrets.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  BadRequestException,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { SecretsService } from './secrets.service';
+
+@Controller('secrets')
+@UseGuards(JwtAuthGuard)
+export class SecretsController {
+  constructor(private readonly secretsService: SecretsService) {}
+
+  /**
+   * GET /secrets - List secret names (NOT values)
+   */
+  @Get()
+  async listSecrets(): Promise<{ names: string[] }> {
+    const names = await this.secretsService.listSecrets();
+    return { names };
+  }
+
+  /**
+   * POST /secrets - Create or update a secret
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async setSecret(
+    @Body() body: { name: string; value: string },
+  ): Promise<{ success: boolean; name: string }> {
+    if (!body.name || typeof body.name !== 'string') {
+      throw new BadRequestException('name is required');
+    }
+    if (!body.value || typeof body.value !== 'string') {
+      throw new BadRequestException('value is required');
+    }
+
+    await this.secretsService.setSecret(body.name, body.value);
+    return { success: true, name: body.name };
+  }
+
+  /**
+   * DELETE /secrets/:name - Delete a secret
+   */
+  @Delete(':name')
+  @HttpCode(HttpStatus.OK)
+  async deleteSecret(
+    @Param('name') name: string,
+  ): Promise<{ success: boolean; name: string }> {
+    await this.secretsService.deleteSecret(name);
+    return { success: true, name };
+  }
+
+  /**
+   * POST /secrets/:name/test - Test that a secret can be resolved
+   * Returns boolean, never the value itself.
+   */
+  @Post(':name/test')
+  @HttpCode(HttpStatus.OK)
+  async testSecret(
+    @Param('name') name: string,
+  ): Promise<{ exists: boolean; name: string }> {
+    const value = await this.secretsService.getSecret(name);
+    return { exists: value !== null, name };
+  }
+}

--- a/backend/src/modules/secrets/secrets.module.ts
+++ b/backend/src/modules/secrets/secrets.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { DatabaseModule } from '../database/database.module';
+import { SecretsService } from './secrets.service';
+import { SecretsController } from './secrets.controller';
+
+@Module({
+  imports: [ConfigModule, DatabaseModule],
+  controllers: [SecretsController],
+  providers: [SecretsService],
+  exports: [SecretsService],
+})
+export class SecretsModule {}

--- a/backend/src/modules/secrets/secrets.service.ts
+++ b/backend/src/modules/secrets/secrets.service.ts
@@ -1,0 +1,161 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PlatformService } from '../database/platform.service';
+import {
+  ISecretsProvider,
+  LocalSecretsProvider,
+  EnvSecretsProvider,
+  VaultSecretsProvider,
+} from './providers';
+
+export type SecretsProviderType = 'local' | 'env' | 'vault';
+
+/**
+ * SecretsService provides a unified interface for managing secrets
+ * across different backends (local encrypted DB, env vars, HashiCorp Vault).
+ *
+ * The provider is selected via the SECRETS_PROVIDER env var.
+ */
+@Injectable()
+export class SecretsService implements OnModuleInit {
+  private readonly logger = new Logger(SecretsService.name);
+  private provider: ISecretsProvider;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly platformService: PlatformService,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    const providerType = this.configService.get<string>(
+      'SECRETS_PROVIDER',
+      'local',
+    ) as SecretsProviderType;
+
+    this.logger.log(`Initializing secrets provider: ${providerType}`);
+
+    switch (providerType) {
+      case 'env':
+        this.provider = new EnvSecretsProvider();
+        break;
+
+      case 'vault': {
+        const vaultAddr = this.configService.get<string>('VAULT_ADDR', '');
+        const vaultToken = this.configService.get<string>('VAULT_TOKEN', '');
+        this.provider = new VaultSecretsProvider(vaultAddr, vaultToken);
+        break;
+      }
+
+      case 'local':
+      default: {
+        const encryptionKey = this.configService.get<string>(
+          'SECRETS_ENCRYPTION_KEY',
+          '',
+        );
+        if (!encryptionKey) {
+          this.logger.warn(
+            'SECRETS_ENCRYPTION_KEY is not set. Local secrets provider will fail on use. ' +
+            'Set SECRETS_ENCRYPTION_KEY (min 32 chars) or switch to a different SECRETS_PROVIDER.',
+          );
+          // Create a dummy provider that always throws
+          this.provider = {
+            getSecret: async () => { throw new Error('SECRETS_ENCRYPTION_KEY is not configured'); },
+            listSecrets: async () => { throw new Error('SECRETS_ENCRYPTION_KEY is not configured'); },
+            setSecret: async () => { throw new Error('SECRETS_ENCRYPTION_KEY is not configured'); },
+            deleteSecret: async () => { throw new Error('SECRETS_ENCRYPTION_KEY is not configured'); },
+          };
+          return;
+        }
+        await this.ensureSecretsTable();
+        this.provider = new LocalSecretsProvider(this.platformService, encryptionKey);
+        break;
+      }
+    }
+
+    this.logger.log(`Secrets provider "${providerType}" initialized`);
+  }
+
+  /**
+   * Create the secrets table if it does not exist (local provider only).
+   */
+  private async ensureSecretsTable(): Promise<void> {
+    await this.platformService.query(`
+      CREATE TABLE IF NOT EXISTS secrets (
+        id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        name VARCHAR(255) UNIQUE NOT NULL,
+        encrypted_value TEXT NOT NULL,
+        iv VARCHAR(64) NOT NULL,
+        tag VARCHAR(64) NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `);
+    this.logger.log('Secrets table ensured');
+  }
+
+  /** Fetch a secret by name from the configured provider */
+  async getSecret(name: string): Promise<string | null> {
+    return this.provider.getSecret(name);
+  }
+
+  /** List available secret names (not values) */
+  async listSecrets(): Promise<string[]> {
+    return this.provider.listSecrets();
+  }
+
+  /** Store a secret (for the local provider) */
+  async setSecret(name: string, value: string): Promise<void> {
+    return this.provider.setSecret(name, value);
+  }
+
+  /** Delete a secret */
+  async deleteSecret(name: string): Promise<void> {
+    return this.provider.deleteSecret(name);
+  }
+
+  /**
+   * Resolve all {{secrets.NAME}} placeholders in a string.
+   * Returns the string with secrets replaced by their values.
+   */
+  async resolveSecrets(input: string): Promise<string> {
+    const regex = /\{\{secrets\.([^}]+)\}\}/g;
+    const matches: Array<{ full: string; name: string }> = [];
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(input)) !== null) {
+      matches.push({ full: match[0], name: match[1] });
+    }
+
+    if (matches.length === 0) return input;
+
+    let result = input;
+    for (const m of matches) {
+      const value = await this.getSecret(m.name);
+      if (value !== null) {
+        result = result.replace(m.full, value);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Recursively resolve {{secrets.NAME}} in any object/array/string structure.
+   * Used by the execution engine to resolve secrets in node configs.
+   */
+  async resolveSecretsInObject(obj: any): Promise<any> {
+    if (typeof obj === 'string') {
+      return this.resolveSecrets(obj);
+    }
+    if (Array.isArray(obj)) {
+      return Promise.all(obj.map((item) => this.resolveSecretsInObject(item)));
+    }
+    if (obj && typeof obj === 'object') {
+      const resolved: any = {};
+      for (const [key, value] of Object.entries(obj)) {
+        resolved[key] = await this.resolveSecretsInObject(value);
+      }
+      return resolved;
+    }
+    return obj;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `SecretsModule` with a provider-based architecture supporting three backends: **local** (AES-256-GCM encrypted in PostgreSQL), **env** (read from environment variables), and **vault** (HashiCorp Vault via HTTP API)
- Integrates with the workflow execution engine to resolve `{{secrets.NAME}}` references in node configs before each node executes
- Adds REST API endpoints for managing secrets (`GET /secrets`, `POST /secrets`, `DELETE /secrets/:name`, `POST /secrets/:name/test`) — values are never exposed through the API

## Details
- Provider selected via `SECRETS_PROVIDER` env var (`local` default, `env`, `vault`)
- Local provider uses AES-256-GCM encryption with key from `SECRETS_ENCRYPTION_KEY`
- Vault provider reads from `VAULT_ADDR` + `VAULT_TOKEN` using KV v2 engine
- Secrets resolution happens in `WorkflowExecutionEngine.processExecutionStack()` before node execution
- Base node executor updated to pass through `secrets.*` expressions for engine-level resolution
- `tsc --noEmit` passes with 0 errors

Closes #123

## Test plan
- [ ] Verify local provider encrypts/decrypts secrets correctly
- [ ] Test env provider reads from process.env
- [ ] Test vault provider against a HashiCorp Vault instance
- [ ] Verify `{{secrets.NAME}}` resolution in workflow node configs
- [ ] Confirm API never returns secret values (only names and existence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)