### PR TITLE
feat: idempotency keys for webhook deduplication

### DIFF
--- a/backend/src/database/migrations/002_add_idempotency_key.sql
+++ b/backend/src/database/migrations/002_add_idempotency_key.sql
@@ -1,0 +1,7 @@
+-- Add idempotency_key column to workflow_executions for webhook deduplication
+ALTER TABLE workflow_executions
+  ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(255);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_executions_idempotency_key
+  ON workflow_executions(idempotency_key)
+  WHERE idempotency_key IS NOT NULL;

--- a/backend/src/modules/database/platform.service.ts
+++ b/backend/src/modules/database/platform.service.ts
@@ -1159,6 +1159,7 @@ export class PlatformService implements OnModuleInit, OnModuleDestroy {
           step_results JSONB DEFAULT '[]',
           context JSONB DEFAULT '{}',
           duration_ms INTEGER,
+          idempotency_key VARCHAR(255),
           started_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
           completed_at TIMESTAMP WITH TIME ZONE,
           created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
@@ -1488,6 +1489,7 @@ export class PlatformService implements OnModuleInit, OnModuleDestroy {
         CREATE INDEX IF NOT EXISTS idx_workflow_executions_app_id ON workflow_executions(app_id);
         CREATE INDEX IF NOT EXISTS idx_workflow_executions_status ON workflow_executions(status);
         CREATE INDEX IF NOT EXISTS idx_workflow_executions_started_at ON workflow_executions(started_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_workflow_executions_idempotency_key ON workflow_executions(idempotency_key) WHERE idempotency_key IS NOT NULL;
 
         CREATE INDEX IF NOT EXISTS idx_workflow_templates_category ON workflow_templates(category);
         CREATE INDEX IF NOT EXISTS idx_workflow_templates_industry ON workflow_templates(industry);

--- a/backend/src/modules/fluxturn/workflow/services/idempotency.service.ts
+++ b/backend/src/modules/fluxturn/workflow/services/idempotency.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PlatformService } from '../../../database/platform.service';
+import * as crypto from 'crypto';
+
+/**
+ * IdempotencyService prevents duplicate workflow executions caused by
+ * the same webhook event being delivered more than once.
+ *
+ * The idempotency key is derived from:
+ *   hash(webhook_url + request_body + timestamp_bucket)
+ *
+ * where timestamp_bucket = floor(timestamp / window_size).
+ *
+ * Before creating a new execution the webhook handler calls
+ * `isDuplicate(key)` -- if an execution with that key already exists
+ * within the dedup window the webhook is silently skipped.
+ */
+@Injectable()
+export class IdempotencyService {
+  private readonly logger = new Logger(IdempotencyService.name);
+
+  /** Default deduplication window in seconds (5 minutes). */
+  private readonly windowSeconds: number;
+
+  constructor(
+    private readonly platformService: PlatformService,
+    private readonly configService: ConfigService,
+  ) {
+    this.windowSeconds = this.configService.get<number>(
+      'IDEMPOTENCY_WINDOW_SECONDS',
+      300,
+    );
+  }
+
+  /**
+   * Derive an idempotency key from webhook URL, body, and current time.
+   */
+  generateKey(webhookUrl: string, body: string | object): string {
+    const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
+    const bucket = Math.floor(Date.now() / 1000 / this.windowSeconds);
+    const raw = `${webhookUrl}:${bodyStr}:${bucket}`;
+    return crypto.createHash('sha256').update(raw).digest('hex');
+  }
+
+  /**
+   * Returns `true` if an execution with the given key already exists
+   * within the configured dedup window (i.e. this is a duplicate).
+   */
+  async isDuplicate(idempotencyKey: string): Promise<boolean> {
+    try {
+      const result = await this.platformService.query(
+        `SELECT id FROM workflow_executions
+         WHERE idempotency_key = $1
+           AND started_at >= NOW() - INTERVAL '${this.windowSeconds} seconds'
+         LIMIT 1`,
+        [idempotencyKey],
+      );
+      return result.rows.length > 0;
+    } catch (error) {
+      // If the column doesn't exist yet (migration pending) never block
+      this.logger.warn(
+        'Idempotency check failed -- allowing execution',
+        error.message,
+      );
+      return false;
+    }
+  }
+}

--- a/backend/src/modules/fluxturn/workflow/webhook.controller.ts
+++ b/backend/src/modules/fluxturn/workflow/webhook.controller.ts
@@ -12,6 +12,7 @@ import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { WorkflowService } from './workflow.service';
 import { WebhookAuthService } from './services/webhook-auth.service';
+import { IdempotencyService } from './services/idempotency.service';
 
 /**
  * Generic Webhook Controller
@@ -35,6 +36,7 @@ export class WebhookController {
   constructor(
     private readonly workflowService: WorkflowService,
     private readonly webhookAuthService: WebhookAuthService,
+    private readonly idempotencyService: IdempotencyService,
   ) {}
 
   @All(':workflowId')
@@ -158,6 +160,22 @@ export class WebhookController {
         });
       }
 
+      // Idempotency check: skip duplicate webhook deliveries
+      const idempotencyKey = this.idempotencyService.generateKey(
+        req.originalUrl || req.path,
+        req.body,
+      );
+
+      const isDuplicate = await this.idempotencyService.isDuplicate(idempotencyKey);
+      if (isDuplicate) {
+        this.logger.log(`Duplicate webhook detected for workflow ${workflowId}, key=${idempotencyKey.slice(0, 12)}...`);
+        return res.status(HttpStatus.OK).json({
+          success: true,
+          deduplicated: true,
+          message: 'Duplicate webhook detected, execution skipped',
+        });
+      }
+
       // Prepare webhook data for workflow execution
       const webhookData = {
         method: req.method,
@@ -189,7 +207,7 @@ export class WebhookController {
         res.status(responseCode).json(responseData);
 
         // Execute workflow asynchronously
-        this.executeWorkflowAsync(workflow, workflowId, webhookData, startTime);
+        this.executeWorkflowAsync(workflow, workflowId, webhookData, startTime, idempotencyKey);
 
         return;
       }
@@ -200,6 +218,7 @@ export class WebhookController {
         input_data: webhookData,
         organization_id: workflow.organization_id,
         project_id: workflow.project_id,
+        idempotency_key: idempotencyKey,
       });
 
       const executionTime = Date.now() - startTime;
@@ -245,7 +264,8 @@ export class WebhookController {
     workflow: any,
     workflowId: string,
     webhookData: any,
-    startTime: number
+    startTime: number,
+    idempotencyKey?: string,
   ) {
     try {
       await this.workflowService.executeWorkflow({
@@ -253,6 +273,7 @@ export class WebhookController {
         input_data: webhookData,
         organization_id: workflow.organization_id,
         project_id: workflow.project_id,
+        idempotency_key: idempotencyKey,
       });
 
       const executionTime = Date.now() - startTime;

--- a/backend/src/modules/fluxturn/workflow/workflow.module.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.module.ts
@@ -8,6 +8,7 @@ import { WebhookController } from './webhook.controller';
 import { WorkflowService } from './workflow.service';
 import { TemplateService } from './services/template.service';
 import { WebhookAuthService } from './services/webhook-auth.service';
+import { IdempotencyService } from './services/idempotency.service';
 import { DatabaseModule } from '../../database/database.module';
 import { QueueModule } from '../../queue/queue.module';
 import { ConnectorsModule } from '../connectors/connectors.module';
@@ -136,6 +137,7 @@ import { OrchestratedGeneratorService } from './services/orchestrated-generator.
     ControlFlowService,
     // Webhook services
     WebhookAuthService,
+    IdempotencyService,
     // Trigger infrastructure
     TriggerManagerService,
     // Gmail trigger services

--- a/backend/src/modules/fluxturn/workflow/workflow.service.ts
+++ b/backend/src/modules/fluxturn/workflow/workflow.service.ts
@@ -323,6 +323,7 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
     input_data?: Record<string, any>;
     project_id?: string;
     organization_id?: string;
+    idempotency_key?: string;
   }): Promise<any> {
     try {
       // Get workflow from database
@@ -361,10 +362,12 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         INSERT INTO workflow_executions (
           id, workflow_id, organization_id, project_id,
           execution_number, status, input_data, total_steps,
+          idempotency_key,
           started_at, created_at
         ) VALUES (
           $1, $2, $3, $4,
           $5, $6, $7, $8,
+          $9,
           NOW(), NOW()
         ) RETURNING *
       `;
@@ -377,7 +380,8 @@ export class WorkflowService implements OnModuleInit, OnModuleDestroy {
         executionNumber,
         'running',
         JSON.stringify(params.input_data || {}),
-        canvas.nodes.length
+        canvas.nodes.length,
+        params.idempotency_key || null,
       ];
 
       await this.platformService.query(insertExecutionQuery, executionValues);


### PR DESCRIPTION
## Summary
- Adds `IdempotencyService` that generates SHA-256 keys from `hash(webhook_url + body + timestamp_bucket)` where `timestamp_bucket = floor(now / window_size)`.
- Before executing a webhook-triggered workflow, checks if an execution with the same key exists within the dedup window (default 5 min, configurable via `IDEMPOTENCY_WINDOW_SECONDS` env var). Duplicates return 200 with `deduplicated: true`.
- Adds `idempotency_key VARCHAR(255)` column to `workflow_executions` with a partial index, plus a standalone migration file.

Closes #132

## Test plan
- [ ] Send the same webhook payload twice within 5 minutes -- second call should return `deduplicated: true`
- [ ] Send the same payload after 5+ minutes -- should execute normally
- [ ] Verify `tsc --noEmit` passes (0 errors from idempotency code)
- [ ] Run migration `002_add_idempotency_key.sql` against existing DB

Generated with [Claude Code](https://claude.com/claude-code)